### PR TITLE
fix: the local develop URL doesn't work without GitHub repo pathname

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ $ cd github1s
 $ yarn
 $ yarn watch
 $ yarn serve # in another shell
-$ # Then visit http://localhost:5000 once the build is completed.
+$ # Then visit http://localhost:5000 or http://localhost:5000/conwnet/github1s once the build is completed.
 ```
 
 ## Build

--- a/scripts/serve-dist.js
+++ b/scripts/serve-dist.js
@@ -7,7 +7,7 @@ const http = require('http');
 const handler = require('serve-handler');
 
 const APP_ROOT = path.join(__dirname, '..');
-const options = { public: path.join(APP_ROOT, 'dist'), cleanUrls: false, };
+const options = { public: path.join(APP_ROOT, 'dist'), cleanUrls: true, };
 
 const server = http.createServer((request, response) => {
   const urlObj = url.parse(request.url);

--- a/scripts/serve-dist.js
+++ b/scripts/serve-dist.js
@@ -7,12 +7,12 @@ const http = require('http');
 const handler = require('serve-handler');
 
 const APP_ROOT = path.join(__dirname, '..');
-const options = { public: path.join(APP_ROOT, 'dist'), cleanUrls: true, };
+const options = { public: path.join(APP_ROOT, 'dist'), cleanUrls: false, };
 
 const server = http.createServer((request, response) => {
   const urlObj = url.parse(request.url);
   return fs.access(path.join(APP_ROOT, 'dist', urlObj.pathname), fs.constants.F_OK, (error) => {
-    if (!error) return handler(request, response, options);
+    if (!error && urlObj.pathname !== '/') return handler(request, response, options);
     return handler(request, response, { rewrites: [{ source: '*', destination: '/index.html' }], ...options });
   });
 });


### PR DESCRIPTION
When developing on localhost, the http://localhost:5000 returns a directory view instead of the web app.

![image](https://user-images.githubusercontent.com/503123/107309013-85c92280-6a3e-11eb-8647-68034e8b29d8.png)

Change the `serve-handler` config will solve the issue.