### PR TITLE
Support URL Encoded Forward Slash

### DIFF
--- a/src/vs/github1s/util.ts
+++ b/src/vs/github1s/util.ts
@@ -15,7 +15,7 @@ interface GitHubRouteState {
 
 export const parseGitHubUrl = (url: string): GitHubRouteState => {
 	const urlObj = new window.URL(url);
-	const parts = urlObj.pathname.split('/').filter(Boolean);
+	const parts = urlObj.pathname.split(/\/|%2F/g).filter(Boolean);
 	const hasFileType = ['tree', 'blob'].includes(parts[2]);
 	const hasBranchName = hasFileType && parts[3];
 


### PR DESCRIPTION
👋  I wanted to be able to be able to use this repo with Alfred's Web Search feature. The query provided to Alfred is automatically URL encoded, so simply splitting on `/` doesn't work. This is kind of a fringe use case, so no issues if you don't want to go down this road.