### PR TITLE
fix: GraphQL query can't handle binary file

### DIFF
--- a/extensions/github1s/src/client.ts
+++ b/extensions/github1s/src/client.ts
@@ -37,6 +37,7 @@ query objectQuery($owner: String! $repo: String! $expression: String!) {
               oid
               byteSize
               text
+              isBinary
             }
             ... on Tree {
               entries {

--- a/extensions/github1s/src/github1sfs.ts
+++ b/extensions/github1s/src/github1sfs.ts
@@ -22,8 +22,6 @@ import { toUint8Array as decodeBase64 } from 'js-base64';
 
 const textEncoder = new TextEncoder();
 
-// graph_sql has some problems now, disable it temporary
-// https://github.com/conwnet/github1s/issues/90
 const ENABLE_GRAPH_SQL: boolean = true;
 
 export class File implements FileStat {

--- a/extensions/github1s/src/github1sfs.ts
+++ b/extensions/github1s/src/github1sfs.ts
@@ -24,7 +24,7 @@ const textEncoder = new TextEncoder();
 
 // graph_sql has some problems now, disable it temporary
 // https://github.com/conwnet/github1s/issues/90
-const ENABLE_GRAPH_SQL: boolean = false;
+const ENABLE_GRAPH_SQL: boolean = true;
 
 export class File implements FileStat {
 	type: FileType;
@@ -89,7 +89,12 @@ const entriesToMap = (entries, uri) => {
 		const fileType: FileType = item.type === 'tree' ? FileType.Directory : FileType.File;
 		const entry = fileType === FileType.Directory
 			? new Directory(uri, item.name, { sha: item.oid })
-			: new File(uri, item.name, { sha: item.oid, size: item.object?.byteSize, data: textEncoder.encode(item?.object?.text) });
+			: new File(uri, item.name, {
+				sha: item.oid,
+				size: item.object?.byteSize,
+				// Set data to `null` if the blob is binary so that it will trigger the RESTful endpoint fallback.
+				data: item.object?.isBinary ? null : textEncoder.encode(item?.object?.text)
+			});
 		map.set(item.name, entry);
 	});
 	return map;
@@ -224,23 +229,11 @@ export class GitHub1sFS implements FileSystemProvider, Disposable {
 				return file.data;
 			}
 
-			if (hasValidToken() && ENABLE_GRAPH_SQL) {
-				const state = parseUri(uri);
-				const path = state.path.substring(1);
-				const directory = dirname(path);
-				return apolloClient.query({
-					query: githubObjectQuery, variables: {
-						owner: state.owner,
-						repo: state.repo,
-						expression: `${state.branch}:${directory}`
-					}
-				})
-					.then((response) => {
-						const entry = (response.data?.repository?.object?.entries || []).find(x => x.path === path);
-						return textEncoder.encode(entry?.object?.text);
-					});
-			}
-
+			/**
+			 * Below code will only be triggered in two cases:
+			 *   1. The GraphQL query is disabled
+			 *   2. The GraphQL query is enabled, but the blob/file is binary
+			 */
 			return readGitHubFile(uri, file.sha).then(blob => {
 				file.data = decodeBase64(blob.content);
 				return file.data;


### PR DESCRIPTION
The GraphQL query should never be executed in `readFile` function. Because the GraphQL query always reads all file content from the directory level.

Assume GraphQL is enabled, when the `readFile` is triggered, the related `readDirectory` of the file's directory must be executed already. If the file is a text file and the `File` object must have valid `data`, and the only case it has `data: null` is the file itself is binary, thus execute the query again wouldn't add any value. So we need to directly call the RESTful endpoint to get the file content.

Before this fix:
![image](https://user-images.githubusercontent.com/503123/107831991-30458c00-6d44-11eb-8c7c-b061c5650529.png)

After fix:
![image](https://user-images.githubusercontent.com/503123/107832020-3cc9e480-6d44-11eb-993e-4a06e271ee35.png)
