### PR TITLE
feat: use 4 level traversal to optimize the GraphQL query times

### DIFF
--- a/extensions/github1s/src/client.ts
+++ b/extensions/github1s/src/client.ts
@@ -22,34 +22,59 @@ const authLink = setContext((_, { headers }) => {
 });
 
 export const githubObjectQuery = gql`
-query objectQuery($owner: String! $repo: String! $expression: String!) {
-  repository(name: $repo, owner: $owner) {
-    id
-    object(expression: $expression) {
+fragment TreeEntryFields on TreeEntry {
+  oid
+  name
+  path
+  type
+}
+
+fragment BlobFields on Blob {
+  oid
+  byteSize
+  text
+  isBinary
+}
+
+fragment TreeField on Tree {
+  id
+  entries {
+    ...TreeEntryFields
+    object {
+      ...BlobFields
       ... on Tree {
         entries {
-          oid
-          name
-          path
-          type
+          ...TreeEntryFields
           object {
-            ... on Blob {
-              oid
-              byteSize
-              text
-              isBinary
-            }
+            ...BlobFields
             ... on Tree {
               entries {
-                oid
-                name
-                path
-                type
+                ...TreeEntryFields
+                object {
+                  ...BlobFields
+                  ... on Tree {
+                    entries {
+                      ...TreeEntryFields
+                      object {
+                        ...BlobFields
+                      }
+                    }
+                  }
+                }
               }
             }
           }
         }
       }
+    }
+  }
+}
+
+query objectQuery($owner: String!, $repo: String!, $expression: String!) {
+  repository(name: $repo, owner: $owner) {
+    id
+    object(expression: $expression) {
+      ...TreeField
     }
   }
 }

--- a/extensions/github1s/src/github1sfs.ts
+++ b/extensions/github1s/src/github1sfs.ts
@@ -86,15 +86,19 @@ const entriesToMap = (entries, uri) => {
 	}
 	const map = new Map<string, Entry>();
 	entries.forEach((item: any) => {
-		const fileType: FileType = item.type === 'tree' ? FileType.Directory : FileType.File;
-		const entry = fileType === FileType.Directory
-			? new Directory(uri, item.name, { sha: item.oid })
-			: new File(uri, item.name, {
+		const isDirectory = item.type === 'tree';
+		let entry;
+		if (isDirectory) {
+			entry = new Directory(uri, item.name, { sha: item.oid });
+			entry.entries = entriesToMap(item?.object?.entries, Uri.joinPath(uri, item.name));
+		} else {
+			entry = new File(uri, item.name, {
 				sha: item.oid,
 				size: item.object?.byteSize,
 				// Set data to `null` if the blob is binary so that it will trigger the RESTful endpoint fallback.
 				data: item.object?.isBinary ? null : textEncoder.encode(item?.object?.text)
 			});
+		}
 		map.set(item.name, entry);
 	});
 	return map;


### PR DESCRIPTION
This PR depends on #96 

After this change, one GraphQL query will return 4 level file information.

![image](https://user-images.githubusercontent.com/503123/107835832-b3201400-6d4f-11eb-9dbc-ddfeb24615fb.png)
