### PR TITLE
feat: add loading spinner for inital page

### DIFF
--- a/resources/index-hash.html
+++ b/resources/index-hash.html
@@ -16,12 +16,106 @@
 		<link rel="icon" href="/favicon.ico" type="image/x-icon" />
 		<link rel="manifest" href="/manifest.json">
 		<title>GitHub1s</title>
+		<style>
+			#load-spinner {
+				width: 100vw;
+				text-align: center;
+				padding-top: 100px;
+			}
+			.lds-roller {
+			  display: inline-block;
+			  position: relative;
+			  width: 80px;
+			  height: 80px;
+			}
+			.lds-roller div {
+			  animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+			  transform-origin: 40px 40px;
+			}
+			.lds-roller div:after {
+			  content: " ";
+			  display: block;
+			  position: absolute;
+			  width: 7px;
+			  height: 7px;
+			  border-radius: 50%;
+			  background: #000;
+			  margin: -4px 0 0 -4px;
+			}
+			.lds-roller div:nth-child(1) {
+			  animation-delay: -0.036s;
+			}
+			.lds-roller div:nth-child(1):after {
+			  top: 63px;
+			  left: 63px;
+			}
+			.lds-roller div:nth-child(2) {
+			  animation-delay: -0.072s;
+			}
+			.lds-roller div:nth-child(2):after {
+			  top: 68px;
+			  left: 56px;
+			}
+			.lds-roller div:nth-child(3) {
+			  animation-delay: -0.108s;
+			}
+			.lds-roller div:nth-child(3):after {
+			  top: 71px;
+			  left: 48px;
+			}
+			.lds-roller div:nth-child(4) {
+			  animation-delay: -0.144s;
+			}
+			.lds-roller div:nth-child(4):after {
+			  top: 72px;
+			  left: 40px;
+			}
+			.lds-roller div:nth-child(5) {
+			  animation-delay: -0.18s;
+			}
+			.lds-roller div:nth-child(5):after {
+			  top: 71px;
+			  left: 32px;
+			}
+			.lds-roller div:nth-child(6) {
+			  animation-delay: -0.216s;
+			}
+			.lds-roller div:nth-child(6):after {
+			  top: 68px;
+			  left: 24px;
+			}
+			.lds-roller div:nth-child(7) {
+			  animation-delay: -0.252s;
+			}
+			.lds-roller div:nth-child(7):after {
+			  top: 63px;
+			  left: 17px;
+			}
+			.lds-roller div:nth-child(8) {
+			  animation-delay: -0.288s;
+			}
+			.lds-roller div:nth-child(8):after {
+			  top: 56px;
+			  left: 12px;
+			}
+			@keyframes lds-roller {
+			  0% {
+			    transform: rotate(0deg);
+			  }
+			  100% {
+			    transform: rotate(360deg);
+			  }
+			}
+		</style>
 	</head>
 
 	<body aria-label="">
 		<noscript title="No JavaScript Support">
 			<h1>You need to enable JavaScript to run this app.</h1>
 		</noscript>
+		<div id='load-spinner' aria-label="loading">
+			<div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+		</div>
 	</body>
 
 	<script>

--- a/resources/index.html
+++ b/resources/index.html
@@ -16,12 +16,106 @@
 		<link rel="icon" href="/favicon.ico" type="image/x-icon" />
 		<link rel="manifest" href="/manifest.json">
 		<title>GitHub1s</title>
+		<style>
+			#load-spinner {
+				width: 100vw;
+				text-align: center;
+				padding-top: 100px;
+			}
+			.lds-roller {
+			  display: inline-block;
+			  position: relative;
+			  width: 80px;
+			  height: 80px;
+			}
+			.lds-roller div {
+			  animation: lds-roller 1.2s cubic-bezier(0.5, 0, 0.5, 1) infinite;
+			  transform-origin: 40px 40px;
+			}
+			.lds-roller div:after {
+			  content: " ";
+			  display: block;
+			  position: absolute;
+			  width: 7px;
+			  height: 7px;
+			  border-radius: 50%;
+			  background: #000;
+			  margin: -4px 0 0 -4px;
+			}
+			.lds-roller div:nth-child(1) {
+			  animation-delay: -0.036s;
+			}
+			.lds-roller div:nth-child(1):after {
+			  top: 63px;
+			  left: 63px;
+			}
+			.lds-roller div:nth-child(2) {
+			  animation-delay: -0.072s;
+			}
+			.lds-roller div:nth-child(2):after {
+			  top: 68px;
+			  left: 56px;
+			}
+			.lds-roller div:nth-child(3) {
+			  animation-delay: -0.108s;
+			}
+			.lds-roller div:nth-child(3):after {
+			  top: 71px;
+			  left: 48px;
+			}
+			.lds-roller div:nth-child(4) {
+			  animation-delay: -0.144s;
+			}
+			.lds-roller div:nth-child(4):after {
+			  top: 72px;
+			  left: 40px;
+			}
+			.lds-roller div:nth-child(5) {
+			  animation-delay: -0.18s;
+			}
+			.lds-roller div:nth-child(5):after {
+			  top: 71px;
+			  left: 32px;
+			}
+			.lds-roller div:nth-child(6) {
+			  animation-delay: -0.216s;
+			}
+			.lds-roller div:nth-child(6):after {
+			  top: 68px;
+			  left: 24px;
+			}
+			.lds-roller div:nth-child(7) {
+			  animation-delay: -0.252s;
+			}
+			.lds-roller div:nth-child(7):after {
+			  top: 63px;
+			  left: 17px;
+			}
+			.lds-roller div:nth-child(8) {
+			  animation-delay: -0.288s;
+			}
+			.lds-roller div:nth-child(8):after {
+			  top: 56px;
+			  left: 12px;
+			}
+			@keyframes lds-roller {
+			  0% {
+			    transform: rotate(0deg);
+			  }
+			  100% {
+			    transform: rotate(360deg);
+			  }
+			}
+		</style>
 	</head>
 
 	<body aria-label="">
 		<noscript title="No JavaScript Support">
 			<h1>You need to enable JavaScript to run this app.</h1>
 		</noscript>
+		<div id='load-spinner' aria-label="loading">
+			<div class="lds-roller"><div></div><div></div><div></div><div></div><div></div><div></div><div></div><div></div></div>
+		</div>
 	</body>
 
 	<script>

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -518,6 +518,9 @@ class WindowIndicator implements IWindowIndicator {
 		}
 	} : undefined;
 
+	// Remove the html load spinner
+	document.querySelector('#load-spinner')?.remove();
+
 	// Finally create workbench
 	create(document.body, {
 		...config,


### PR DESCRIPTION
This depends on the #101 

@conwnet do you think whether we need to change the `index-dev.html` and `index-hash.html` files?

The CSS load spinner from https://loading.io/css/. Please feel free to update it to other implementations.

You can preview on https://github1s-git-load-spinner.xcv58.vercel.app/

![image](https://user-images.githubusercontent.com/503123/107837749-4e68b780-6d57-11eb-978c-f7641e724f60.png)
