### PR TITLE
fix: make GraphQL use one level directory query to support big repo

### DIFF
--- a/extensions/github1s/src/client.ts
+++ b/extensions/github1s/src/client.ts
@@ -47,22 +47,6 @@ fragment TreeField on Tree {
           ...TreeEntryFields
           object {
             ...BlobFields
-            ... on Tree {
-              entries {
-                ...TreeEntryFields
-                object {
-                  ...BlobFields
-                  ... on Tree {
-                    entries {
-                      ...TreeEntryFields
-                      object {
-                        ...BlobFields
-                      }
-                    }
-                  }
-                }
-              }
-            }
           }
         }
       }

--- a/extensions/github1s/src/client.ts
+++ b/extensions/github1s/src/client.ts
@@ -42,14 +42,6 @@ fragment TreeField on Tree {
     ...TreeEntryFields
     object {
       ...BlobFields
-      ... on Tree {
-        entries {
-          ...TreeEntryFields
-          object {
-            ...BlobFields
-          }
-        }
-      }
     }
   }
 }


### PR DESCRIPTION
You can test https://github1s-git-gql-too-large.xcv58.vercel.app/torvalds/linux/blob/HEAD/Documentation/x86/x86_64/boot-options.rst

It seems we have to use one level query to make the query robust:

With only one level:

![image](https://user-images.githubusercontent.com/503123/107862234-53357600-6e00-11eb-8a2f-f5947c623fdd.png)
![image](https://user-images.githubusercontent.com/503123/107862238-5d577480-6e00-11eb-9d46-4cc12fb5014a.png)
![image](https://user-images.githubusercontent.com/503123/107862251-6e07ea80-6e00-11eb-9713-4815c9888e6e.png)


With two levels:
![image](https://user-images.githubusercontent.com/503123/107862210-1cf7f680-6e00-11eb-9929-32da953086dc.png)
![image](https://user-images.githubusercontent.com/503123/107862230-4749b400-6e00-11eb-8cf7-5bc082072a7c.png)

