### PR TITLE
feat: add auto deploy GitHub action based on tags

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,30 @@
+name: Node.js CI
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - v*
+
+jobs:
+  deploy:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup Node
+      uses: actions/setup-node@v1
+      with:
+        node-version: '14.x'
+
+    - run: yarn --frozen-lockfile
+    - run: yarn build
+    # Add command to generate artifact for gh-pages branch
+
+    - name: Deploy
+      uses: peaceiris/actions-gh-pages@v3
+      with:
+        github_token: ${{ secrets.GITHUB_TOKEN }}
+        publish_dir: ./dist

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -19,7 +19,7 @@ jobs:
 
     - run: yarn --frozen-lockfile
     - run: yarn build
-    # Add command to generate artifact for gh-pages branch
+    - run: yarn hash
 
     - name: Deploy
       uses: peaceiris/actions-gh-pages@v3

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -27,3 +27,4 @@ jobs:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist
         cname: github1s.com
+        keep_files: true

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,9 +1,7 @@
-name: Node.js CI
+name: Deploy
 
 on:
   push:
-    branches:
-      - master
     tags:
       - v*
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -26,3 +26,4 @@ jobs:
       with:
         github_token: ${{ secrets.GITHUB_TOKEN }}
         publish_dir: ./dist
+        cname: github1s.com

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,4 +1,4 @@
-name: Deploy
+name: Deploy on tags
 
 on:
   push:

--- a/scripts/hash.sh
+++ b/scripts/hash.sh
@@ -10,7 +10,7 @@ STATIC_FOLDER_NAME="static-${SHORT_COMMIT_ID-unknown}"
 
 if [ -e "${APP_ROOT}/dist/static" ]; then
 	mv "${APP_ROOT}/dist/static" "${APP_ROOT}/dist/${STATIC_FOLDER_NAME}"
-	sed "s/{STATIC_FOLDER}/${STATIC_FOLDER_NAME}/" "${APP_ROOT}/resources/index-hash.html" > "${APP_ROOT}/dist/index.html"
+	sed "s/{STATIC_FOLDER}/${STATIC_FOLDER_NAME}/" "${APP_ROOT}/resources/index-hash.html" > "${APP_ROOT}/dist/404.html"
 	echo "hash static files done"
 else
 	echo "Please build github1s first"


### PR DESCRIPTION
Tested on my repo, with tag:

![image](https://user-images.githubusercontent.com/503123/107915853-24132780-6f1a-11eb-8a6a-8d888e5d43d2.png)

Without tag:
![image](https://user-images.githubusercontent.com/503123/107915872-2d9c8f80-6f1a-11eb-9ac4-5c6d22652958.png)

Action successfully update the gh-pages branch:
https://github.com/xcv58/github1s/runs/1901269075?check_suite_focus=true

https://github.com/xcv58/github1s/runs/1901346185?check_suite_focus=true

https://github.com/xcv58/github1s/tree/gh-pages
commits history:
https://github.com/xcv58/github1s/commits/gh-pages

Sample URL:
https://xcv58.github.io/github1s/
It's broken because of the subpath.