### PR TITLE
feat: set config.webviewEndpoint

### DIFF
--- a/resources/index-dev.html
+++ b/resources/index-dev.html
@@ -8,10 +8,10 @@
 		<meta charset="utf-8" />
 		<!-- Disable pinch zooming -->
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
+		<!-- Workbench Configuration -->
+		<meta id="vscode-workbench-web-configuration" data-settings="">
 		<!-- VS Code Extensions Configuration -->
 		<meta id="vscode-workbench-builtin-extensions" data-settings="[]">
-		<!-- VS Code Web Worker Extension Host Configuration -->
-		<meta id="vscode-extension-host-iframe-src" data-settings="">
 		<!-- Workbench Icon/Manifest/CSS -->
 		<link rel="icon" href="/favicon.ico" type="image/x-icon" />
 		<link rel="manifest" href="/manifest.json">
@@ -55,8 +55,15 @@
 	</script>
 	<script>
 		fetch('/static/configure/extensions.json').then(response => response.text()).then(extensionsJson => {
+			document.getElementById('vscode-workbench-web-configuration').setAttribute('data-settings', JSON.stringify({
+				// the empty authority means github1s should get it from `window.location.href`
+				folderUri: { scheme: "github1s", authority: '', path: '/' },
+				staticExtensions: [],
+				enableSyncByDefault: false,
+				webviewEndpoint: window.location.origin + '/static/vscode/vs/workbench/contrib/webview/browser/pre',
+				webWorkerExtensionHostIframeSrc: '/static/vscode/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html'
+			}));
 			document.getElementById('vscode-workbench-builtin-extensions').setAttribute('data-settings', extensionsJson);
-			document.getElementById('vscode-extension-host-iframe-src').setAttribute('data-settings', '/static/vscode/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html');
 			require(['vs/code/browser/workbench/workbench'], function() {});
 		});
 	</script>

--- a/resources/index-hash.html
+++ b/resources/index-hash.html
@@ -8,10 +8,10 @@
 		<meta charset="utf-8" />
 		<!-- Disable pinch zooming -->
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
+		<!-- Workbench Configuration -->
+		<meta id="vscode-workbench-web-configuration" data-settings="">
 		<!-- VS Code Extensions Configuration -->
 		<meta id="vscode-workbench-builtin-extensions" data-settings="[]">
-		<!-- VS Code Web Worker Extension Host Configuration -->
-		<meta id="vscode-extension-host-iframe-src" data-settings="">
 		<!-- Workbench Icon/Manifest/CSS -->
 		<link rel="icon" href="/favicon.ico" type="image/x-icon" />
 		<link rel="manifest" href="/manifest.json">
@@ -150,8 +150,15 @@
 	</script>
 	<script>
 		fetch('/{STATIC_FOLDER}/configure/extensions.json').then(response => response.text()).then(extensionsJson => {
+			document.getElementById('vscode-workbench-web-configuration').setAttribute('data-settings', JSON.stringify({
+				// the empty authority means github1s should get it from `window.location.href`
+				folderUri: { scheme: "github1s", authority: '', path: '/' },
+				staticExtensions: [],
+				enableSyncByDefault: false,
+				webviewEndpoint: window.location.origin + '/{STATIC_FOLDER}/vscode/vs/workbench/contrib/webview/browser/pre',
+				webWorkerExtensionHostIframeSrc: '/{STATIC_FOLDER}/vscode/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html'
+			}));
 			document.getElementById('vscode-workbench-builtin-extensions').setAttribute('data-settings', extensionsJson);
-	document.getElementById('vscode-extension-host-iframe-src').setAttribute('data-settings', '/{STATIC_FOLDER}/vscode/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html');
 			require(['vs/code/browser/workbench/workbench'], function() {});
 		});
 	</script>

--- a/resources/index.html
+++ b/resources/index.html
@@ -8,10 +8,10 @@
 		<meta charset="utf-8" />
 		<!-- Disable pinch zooming -->
 		<meta name="viewport" content="width=device-width, initial-scale=1.0, maximum-scale=1.0, minimum-scale=1.0, user-scalable=no">
+		<!-- Workbench Configuration -->
+		<meta id="vscode-workbench-web-configuration" data-settings="">
 		<!-- VS Code Extensions Configuration -->
 		<meta id="vscode-workbench-builtin-extensions" data-settings="[]">
-		<!-- VS Code Web Worker Extension Host Configuration -->
-		<meta id="vscode-extension-host-iframe-src" data-settings="">
 		<!-- Workbench Icon/Manifest/CSS -->
 		<link rel="icon" href="/favicon.ico" type="image/x-icon" />
 		<link rel="manifest" href="/manifest.json">
@@ -150,8 +150,15 @@
 	</script>
 	<script>
 		fetch('/static/configure/extensions.json').then(response => response.text()).then(extensionsJson => {
+			document.getElementById('vscode-workbench-web-configuration').setAttribute('data-settings', JSON.stringify({
+				// the empty authority means github1s should get it from `window.location.href`
+				folderUri: { scheme: "github1s", authority: '', path: '/' },
+				staticExtensions: [],
+				enableSyncByDefault: false,
+				webviewEndpoint: window.location.origin + '/static/vscode/vs/workbench/contrib/webview/browser/pre',
+				webWorkerExtensionHostIframeSrc: '/static/vscode/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html'
+			}));
 			document.getElementById('vscode-workbench-builtin-extensions').setAttribute('data-settings', extensionsJson);
-			document.getElementById('vscode-extension-host-iframe-src').setAttribute('data-settings', '/static/vscode/vs/workbench/services/extensions/worker/httpWebWorkerExtensionHostIframe.html');
 			require(['vs/code/browser/workbench/workbench'], function() {});
 		});
 	</script>

--- a/src/vs/code/browser/workbench/workbench.ts
+++ b/src/vs/code/browser/workbench/workbench.ts
@@ -405,14 +405,15 @@ class WindowIndicator implements IWindowIndicator {
 }
 
 (function () {
-	const [repoOwner = 'conwnet', repoName = 'github1s'] = (URI.parse(window.location.href).path || '').split('/').filter(Boolean);
-	const config: IWorkbenchConstructionOptions & { folderUri?: UriComponents, workspaceUri?: UriComponents } = {
-		// the empty authority means github1s should get it from `window.location.href`
-		folderUri: URI.from({ scheme: "github1s", path: '/', authority: '' }),
-		staticExtensions: [],
-		enableSyncByDefault: false,
-		webWorkerExtensionHostIframeSrc: document.getElementById('vscode-extension-host-iframe-src')?.getAttribute('data-settings') as string,
-};
+
+	// Find config by checking for DOM
+	const configElement = document.getElementById('vscode-workbench-web-configuration');
+	const configElementAttribute = configElement ? configElement.getAttribute('data-settings') : undefined;
+	if (!configElement || !configElementAttribute) {
+		throw new Error('Missing web configuration element');
+	}
+
+	const config: IWorkbenchConstructionOptions & { folderUri?: UriComponents, workspaceUri?: UriComponents } = JSON.parse(configElementAttribute);
 
 	// Revive static extension locations
 	if (Array.isArray(config.staticExtensions)) {
@@ -480,6 +481,7 @@ class WindowIndicator implements IWindowIndicator {
 	const workspaceProvider = new WorkspaceProvider(workspace, payload);
 
 	// Home Indicator
+	const [repoOwner = 'conwnet', repoName = 'github1s'] = (URI.parse(window.location.href).path || '').split('/').filter(Boolean);
 	const homeIndicator: IHomeIndicator = {
 		href: `https://github.com/${repoOwner}/${repoName}`,
 		icon: 'github',


### PR DESCRIPTION
missing webviewEndpoint will fallback to visit 'https://{{uuid}}.vscode-webview-test.com/{{commit}}'
See: https://github.com/microsoft/vscode/blob/8cb4a6907be408d48e94428aa033bb81af4846a9/src/vs/workbench/services/environment/browser/environmentService.ts#L222