### PR TITLE
fix: couldn't focus corresponding directory from URL

### DIFF
--- a/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
+++ b/src/vs/workbench/contrib/welcome/page/browser/welcomePage.ts
@@ -148,7 +148,8 @@ export class WelcomePageContribution implements IWorkbenchContribution {
 				) {
 					const currentFileUri = URI.from({
 						scheme: 'github1s',
-						authority,
+						// We must not add authority because it would be different with
+						// VS Code internal ExplorerService's authority.
 						path: fileState.path,
 					});
 					fileService


### PR DESCRIPTION
Preview link: https://github1s-git-fix-open-folder.xcv58.vercel.app/xcv58/github1s/tree/index/html/test/src/vs


The failed reason is here: https://github.com/microsoft/vscode/blob/main/src/vs/workbench/contrib/files/common/explorerModel.ts#L367

```js
equalsIgnoreCase(this.resource.authority, resource.authority)
```

`this.resource.authority` would be `''` and `resource.authority` will be the actual one if we set it. If we set it, the comparison would be false thus it stops revealing the directory. 