### PR TITLE
add .devcontainer files to allow VSCode to use Docker for the Dev Env

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -1,0 +1,19 @@
+# See here for image contents: https://github.com/microsoft/vscode-dev-containers/tree/v0.158.0/containers/typescript-node/.devcontainer/base.Dockerfile
+
+# [Choice] Node.js version: 14, 12, 10
+ARG VARIANT="14-buster"
+FROM mcr.microsoft.com/vscode/devcontainers/typescript-node:0-${VARIANT}
+
+# same package list from github1s/scripts/pre-install.sh
+RUN apt-get update && export DEBIAN_FRONTEND=noninteractive \
+    && apt-get -y install --no-install-recommends libx11-dev libxkbfile-dev libsecret-1-dev rsync
+
+# copied from https://github.com/microsoft/vscode-oniguruma/blob/main/.devcontainer/Dockerfile
+RUN mkdir -p /opt/dev \
+    && cd /opt/dev \
+    && git clone https://github.com/emscripten-core/emsdk.git \
+    && cd /opt/dev/emsdk \
+    && ./emsdk install 2.0.6 \
+    && ./emsdk activate 2.0.6
+
+ENV PATH="/opt/dev/emsdk:/opt/dev/emsdk/node/12.9.1_64bit/bin:/opt/dev/emsdk/upstream/emscripten:${PATH}"

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,31 @@
+// For format details, see https://aka.ms/devcontainer.json. For config options, see the README at:
+// https://github.com/microsoft/vscode-dev-containers/tree/v0.158.0/containers/typescript-node
+{
+	"name": "Node.js & TypeScript",
+	"build": {
+		"dockerfile": "Dockerfile",
+		// Update 'VARIANT' to pick a Node version: 10, 12, 14
+		"args": { 
+			"VARIANT": "12"
+		}
+	},
+
+	// Set *default* container specific settings.json values on container create.
+	"settings": { 
+		"terminal.integrated.shell.linux": "/bin/bash"
+	},
+
+	// Add the IDs of extensions you want installed when the container is created.
+	"extensions": [
+		"dbaeumer.vscode-eslint"
+	],
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	"forwardPorts": [5000],
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	//"postCreateCommand": "yarn",
+
+	// Comment out connect as root instead. More info: https://aka.ms/vscode-remote/containers/non-root.
+	"remoteUser": "node",
+}

--- a/README.md
+++ b/README.md
@@ -45,6 +45,26 @@ $ yarn serve # in another shell
 $ # Then visit http://localhost:5000 or http://localhost:5000/conwnet/github1s once the build is completed.
 ```
 
+### ... or ... VS Code + Docker Development
+
+You can use the VS Code plugin [Remote-Containers](https://marketplace.visualstudio.com/items?itemName=ms-vscode-remote.remote-containers) `Dev Container` to use a Docker container as a development environment.
+
+1. Install the Remote-Containers plugin in VS Code & Docker
+2. Open the Command Palette (default shortcut `Ctrl+Shift+P`) and choose `Remote-Containers: Clone Repository in Container Volume...`
+3. Enter the repo, in this case `https://github.com/conwnet/github1s.git` or your forked repo
+4. Pick either, `Create a unique volume` or `Create a new volume`
+
+   - Now VS Code will create the docker container and connect to the new container so you can use this as a fully setup environment!
+
+5. Open a new VS Code Terminal, then you can run the `yarn` commands listed above.
+
+```bash
+$ yarn
+$ yarn watch
+$ yarn serve # in another shell
+$ # Then visit http://localhost:5000 or http://localhost:5000/conwnet/github1s once the build is completed.
+```
+
 ### Format all codes
 
 ```bash


### PR DESCRIPTION
add .devcontainer files to allow VSCode to use Docker for the develoment environment