### PR TITLE
feat: replace `List Branches` API with `List matching references` API

### DIFF
--- a/extensions/github1s/src/commands.ts
+++ b/extensions/github1s/src/commands.ts
@@ -6,8 +6,8 @@
 import * as vscode from 'vscode';
 import {
 	getExtensionContext,
-	getRepositoryBranches,
-	getRepositoryTags,
+	getRepositoryBranchRefs,
+	getRepositoryTagRefs,
 	getCurrentRef,
 	getCurrentAuthority,
 	changeCurrentRef,
@@ -115,7 +115,7 @@ export const commandGetCurrentAuthority = (): Promise<string> =>
 	getCurrentAuthority();
 
 export const commandSwitchBranch = () => {
-	return Promise.all([getRepositoryBranches(), getCurrentRef()]).then(
+	return Promise.all([getRepositoryBranchRefs(), getCurrentRef()]).then(
 		([repositoryBranches, currentRef]) =>
 			vscode.window
 				.showQuickPick(
@@ -136,7 +136,7 @@ export const commandSwitchBranch = () => {
 };
 
 export const commandSwitchTag = () => {
-	return Promise.all([getRepositoryTags(), getCurrentRef()]).then(
+	return Promise.all([getRepositoryTagRefs(), getCurrentRef()]).then(
 		([repositoryBranches, currentRef]) =>
 			vscode.window
 				.showQuickPick(

--- a/extensions/github1s/src/util/index.ts
+++ b/extensions/github1s/src/util/index.ts
@@ -15,8 +15,8 @@ export {
 export {
 	getCurrentRef,
 	getCurrentAuthority,
-	getRepositoryBranches,
-	getRepositoryTags,
+	getRepositoryBranchRefs,
+	getRepositoryTagRefs,
 	changeCurrentRef,
 } from './git-ref';
 export { parseGitmodules, parseSubmoduleUrl } from './submodule';


### PR DESCRIPTION
the [List Branches](https://docs.github.com/en/rest/reference/repos#list-branches) API only returned max to 100 branches for per request, we will fetch max to 2 request, so only no more than 200 branches are supported before
[List matching references](https://docs.github.com/en/rest/reference/git#list-matching-references) can returned all branches/tags for a request
and there is an issue for this API https://github.com/github/docs/issues/3863