### PR TITLE
Configure Gitpod online dev environment

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -1,0 +1,6 @@
+FROM gitpod/workspace-full
+
+RUN sudo apt-get update \
+  && sudo apt-get install -y \
+    g++ gcc make python2.7 pkg-config libx11-dev libxkbfile-dev libsecret-1-dev python-is-python3 rsync \
+  && sudo rm -rf /var/lib/apt/lists/*

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,7 @@
 image:
   file: .gitpod.Dockerfile
 tasks:
-  - init: yarn global add js-yaml && yarn && yarn build
+  - init: yarn && yarn build
     command: yarn watch
   - command: yarn serve
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,7 +1,11 @@
 image:
   file: .gitpod.Dockerfile
 tasks:
-  - init: yarn && yarn build
+  - init: |
+      yarn
+      yarn build
+      sed -i 's/The Web Worker Extension Host did not start in 10s/The Web Worker Extension Host did not start in 60s/g' ./lib/vscode/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
+      sed -i 's/}, 10000);/}, 60000);/g' ./lib/vscode/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
     command: yarn watch
   - command: yarn serve
 ports:

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,8 +7,9 @@ tasks:
       mkdir -p lib/vscode/out
       sed -i 's/The Web Worker Extension Host did not start in 10s/The Web Worker Extension Host did not start in 60s/g' ./lib/vscode/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
       sed -i 's/}, 10000);/}, 60000);/g' ./lib/vscode/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
-    command: yarn watch
-  - command: yarn serve
+    command: echo "Please run 'yarn watch'"
+  - openMode: split-right
+    command: echo "Please wait for 'yarn watch' to complete compilation, then run 'yarn serve'"
 ports:
   - port: 5000
     onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -7,9 +7,14 @@ tasks:
       mkdir -p lib/vscode/out
       sed -i 's/The Web Worker Extension Host did not start in 10s/The Web Worker Extension Host did not start in 60s/g' ./lib/vscode/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
       sed -i 's/}, 10000);/}, 60000);/g' ./lib/vscode/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
-    command: echo "Please run 'yarn watch'"
-  - openMode: split-right
-    command: echo "Please wait for 'yarn watch' to complete compilation, then run 'yarn serve'"
+    command: |
+      echo "======================="
+      echo "Please run 'yarn watch'"
+      echo "======================="
+  - command: |
+      echo "==========================================================================="
+      echo "Please wait for 'yarn watch' to complete compilation, then run 'yarn serve'"
+      echo "==========================================================================="
 ports:
   - port: 5000
     onOpen: open-browser

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -6,7 +6,7 @@ tasks:
   - command: yarn serve
 ports:
   - port: 5000
-    onOpen: open-preview
+    onOpen: open-browser
 github:
   prebuilds:
     # enable for the master/default branch (defaults to true)

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -1,0 +1,27 @@
+image:
+  file: .gitpod.Dockerfile
+tasks:
+  - init: yarn global add js-yaml && yarn && yarn build
+    command: yarn watch
+  - command: yarn serve
+ports:
+  - port: 5000
+    onOpen: open-preview
+github:
+  prebuilds:
+    # enable for the master/default branch (defaults to true)
+    master: true
+    # enable for all branches in this repo (defaults to false)
+    branches: true
+    # enable for pull requests coming from this repo (defaults to true)
+    pullRequests: true
+    # enable for pull requests coming from forks (defaults to false)
+    pullRequestsFromForks: true
+    # add a check to pull requests (defaults to true)
+    addCheck: true
+    # add a "Review in Gitpod" button as a comment to pull requests (defaults to false)
+    addComment: true
+    # add a "Review in Gitpod" button to the pull request's description (defaults to false)
+    addBadge: false
+    # add a label once the prebuild is ready to pull requests (defaults to false)
+    addLabel: false

--- a/.gitpod.yml
+++ b/.gitpod.yml
@@ -4,6 +4,7 @@ tasks:
   - init: |
       yarn
       yarn build
+      mkdir -p lib/vscode/out
       sed -i 's/The Web Worker Extension Host did not start in 10s/The Web Worker Extension Host did not start in 60s/g' ./lib/vscode/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
       sed -i 's/}, 10000);/}, 60000);/g' ./lib/vscode/src/vs/workbench/services/extensions/browser/webWorkerExtensionHost.ts
     command: yarn watch

--- a/README.md
+++ b/README.md
@@ -35,6 +35,14 @@ javascript: window.location.href = window.location.href.replace(/github(1s)?.com
 
 ## Development
 
+### Cloud-based development
+
+You can start an online development environment with [Gitpod](https://www.gitpod.io) by clicking the following button:
+
+[![Gitpod ready-to-code](https://img.shields.io/badge/Gitpod-ready--to--code-blue?logo=gitpod)](https://gitpod.io/#https://github.com/conwnet/github1s)
+
+### Local development
+
 You need [these prerequisites (the same ones as for VS Code)](https://github.com/microsoft/vscode/wiki/How-to-Contribute#prerequisites) for development.
 
 ```bash

--- a/extensions/svelte-web/package.json
+++ b/extensions/svelte-web/package.json
@@ -3,7 +3,7 @@
   "version": "0.5.0",
   "description": "Svelte language support for VS Code",
   "scripts": {
-    "build:grammar": "npx js-yaml syntaxes/svelte.tmLanguage.src.yaml > syntaxes/svelte.tmLanguage.json",
+    "build:grammar": "js-yaml syntaxes/svelte.tmLanguage.src.yaml > syntaxes/svelte.tmLanguage.json",
     "build": "npm run build:ts && npm run build:grammar",
     "vscode:prepublish": "npm run build && npm prune --production",
     "compile": "npm run build:grammar",
@@ -119,5 +119,8 @@
         }
       }
     ]
+  },
+  "devDependencies": {
+    "js-yaml": "^4.0.0"
   }
 }


### PR DESCRIPTION
This PR introduces a ready-to-code development environment on [Gitpod](https://www.gitpod.io). With a single click, a new development environment with all prerequisites installed and `yarn && yarn build` already executed starts up.

The "Development" chapter in the `README` provides the link to start the dev environment.

To get the full benefits, please enable the [Gitpod GitHub App](https://github.com/apps/gitpod-io). This enables automated [prebuilds](https://www.gitpod.io/docs/prebuilds) for all branches and PRs.