### PR TITLE
Fix CI failure

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}
-        uses: actions/setup-node@v1
+        uses: actions/setup-node@v2
         with:
           node-version: ${{ matrix.node-version }}
 

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    name: Build & Test on ${{ matrix.os }} with Node ${{ matrix.node-version }}
+    name: Build & Test on ${{ matrix.os }} Node ${{ matrix.node-version }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,13 +31,11 @@ jobs:
       - uses: actions/cache@v2
         with:
           path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
-          key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}
+          key: ${{ runner.os }}-yarn-${{ matrix.node-version }}-${{ hashFiles('**/yarn.lock') }}
           restore-keys: |
-            ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}-${{ matrix.node-version }}
+            ${{ runner.os }}-yarn-${{ matrix.node-version }}
 
-      - run: yarn --frozen-lockfile --network-timeout 500000
-        env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+      - run: yarn --frozen-lockfile
       - run: yarn eslint
       - run: yarn build
       - uses: microsoft/playwright-github-action@v1

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,12 +1,6 @@
 name: Build & Test
 
-on:
-  push:
-    branches:
-      - master
-  pull_request:
-    branches:
-      - master
+on: [push, pull_request]
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    name: Build & Test, ${{ matrix.os }}, Node ${{ matrix.node-version }}
+    name: Build & Test, ${{ matrix.os }}, node.js ${{ matrix.node-version }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,6 +17,8 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
+    name: Build & Test on ${{ matrix.os }} with Node ${{ matrix.node-version }}
+
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,7 +17,7 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    name: Build & Test on ${{ matrix.os }} Node ${{ matrix.node-version }}
+    name: Build & Test, ${{ matrix.os }}, Node ${{ matrix.node-version }}
 
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,7 +12,7 @@ jobs:
   build:
     strategy:
       matrix:
-        os: [ubuntu-latest, macos-latest]
+        os: [ubuntu-latest]
         node-version: [14.x, 15.x]
 
     runs-on: ${{ matrix.os }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -17,8 +17,6 @@ jobs:
 
     runs-on: ${{ matrix.os }}
 
-    name: Build & Test, ${{ matrix.os }}, node.js ${{ matrix.node-version }}
-
     steps:
       - uses: actions/checkout@v2
       - name: Use Node.js ${{ matrix.node-version }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,6 +1,12 @@
 name: Build & Test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -12,8 +12,8 @@ jobs:
   build:
     strategy:
       matrix:
-        node-version: [14.x, 15.x]
         os: [ubuntu-latest, macos-latest]
+        node-version: [14.x, 15.x]
 
     runs-on: ${{ matrix.os }}
 


### PR DESCRIPTION
It seems the GitHub Actions' macOS environment is unstable. Try to remove the timeout restriction and bump the node setup version.


If it still fails randomly, we should disable macOS on CI. 


-------

Failed jobs:
https://github.com/xcv58/github1s/runs/2096965487?check_suite_focus=true
https://github.com/conwnet/github1s/runs/2097192100?check_suite_focus=true

Success jobs:
https://github.com/xcv58/github1s/actions/runs/646879291
https://github.com/xcv58/github1s/actions/runs/646754214

And above commits are almost identical with just metadata change in the yml file.
The macOS job randomly failed on `yarn install`.

We should remove macOS for now to have a reliable CI for other PRs and investigate how to onboard macOS late.