### PR TITLE
feat: preload fuze and full files tree

### DIFF
--- a/extensions/github1s/src/helpers/async.ts
+++ b/extensions/github1s/src/helpers/async.ts
@@ -1,0 +1,31 @@
+/**
+ * @file async related helpers
+ */
+
+// below code is comes from:
+//https://github.com/microsoft/vscode/blob/a3415e669a8f3879c290af5616a8ed45dd0534af/src/vs/base/common/async.ts#L344
+export class Barrier {
+	private _isOpen: boolean;
+	private _promise: Promise<boolean>;
+	private _completePromise!: (v: boolean) => void;
+
+	constructor() {
+		this._isOpen = false;
+		this._promise = new Promise<boolean>((c, e) => {
+			this._completePromise = c;
+		});
+	}
+
+	isOpen(): boolean {
+		return this._isOpen;
+	}
+
+	open(): void {
+		this._isOpen = true;
+		this._completePromise(true);
+	}
+
+	wait(): Promise<boolean> {
+		return this._promise;
+	}
+}

--- a/extensions/github1s/src/listeners/router/explorer.ts
+++ b/extensions/github1s/src/listeners/router/explorer.ts
@@ -7,6 +7,7 @@ import * as vscode from 'vscode';
 import {
 	changedFileDecorationProvider,
 	submoduleDecorationProvider,
+	fileSearchProvider,
 } from '@/providers';
 import { RouterState } from '@/router/types';
 
@@ -28,5 +29,6 @@ export const explorerRouterListener = (
 
 		changedFileDecorationProvider.updateDecorations();
 		submoduleDecorationProvider.updateDecorations();
+		fileSearchProvider.loadFuzeForCurrentAuthority();
 	}
 };

--- a/extensions/github1s/src/providers/fileSearchProvider.ts
+++ b/extensions/github1s/src/providers/fileSearchProvider.ts
@@ -26,10 +26,21 @@ export class GitHub1sFileSearchProvider
 	private readonly disposable: Disposable;
 	private fuseMap: Map<string, Fuse<GithubRESTEntry>> = new Map();
 
-	constructor(private fsProvider: GitHub1sFileSystemProvider) {}
+	constructor(private fsProvider: GitHub1sFileSystemProvider) {
+		// Preload the fuze for better `ctrl/command + p` experience.
+		// Once we have loaded the fuze, it will also populate the files into
+		// fileSystemProvider's cache. So after that, you don't have to send
+		// a request when you open the new directory in explorer late
+		this.loadFuzeForCurrentAuthority();
+	}
 
 	dispose() {
 		this.disposable?.dispose();
+	}
+
+	// load the fuze for current authority
+	async loadFuzeForCurrentAuthority() {
+		return this.getFuse(await router.getAuthority());
 	}
 
 	/**


### PR DESCRIPTION
Now, if the user open a repository in GitHub1s, it will only fetch the first level files. (In order to display the content faster)
And when the user press `Ctrl/Command + P`, it will use the `recursive=true` param of `get-a-tree` API to fetch all files, then populate the files into the fileSystemProvider's cache:
https://github.com/conwnet/github1s/blob/e079f7a8f6d0e94347b1e61f82b8e009f87d8737/extensions/github1s/src/providers/fileSearchProvider.ts#L60

So if we haven't ever press the `Ctrl/Commond + P`, we need make a `get-a-tree` request **every time** you open a new folder, which is **slow and  waste**.

I think we can fetch the full files tree sliently after the page loaded. Although it may waste a request, but it's will not to create a new request when the user opens another folder.

Related API: https://docs.github.com/en/rest/reference/git#get-a-tree
