### PR TITLE
fix: editor will close when open it at first time & add commits route support

### DIFF
--- a/extensions/github1s/src/extension.ts
+++ b/extensions/github1s/src/extension.ts
@@ -54,7 +54,9 @@ export async function activate(context: vscode.ExtensionContext) {
 		);
 	} else if (pageType === PageType.PULL_LIST) {
 		vscode.commands.executeCommand('github1s.views.pull-request-list.focus');
-	} else if (pageType === PageType.PULL) {
+	} else if (pageType === PageType.COMMIT_LIST) {
+		vscode.commands.executeCommand('github1s.views.commit-list.focus');
+	} else if ([PageType.PULL, PageType.COMMIT].includes(pageType)) {
 		vscode.commands.executeCommand('workbench.scm.focus');
 	}
 }

--- a/extensions/github1s/src/listeners/vscode.ts
+++ b/extensions/github1s/src/listeners/vscode.ts
@@ -6,27 +6,37 @@
 import * as vscode from 'vscode';
 import router from '@/router';
 import { PageType } from '@/router/types';
-import { GitHub1sFileSearchProvider } from '@/providers/fileSearchProvider';
+import { GitHub1sFileSystemProvider } from '@/providers/fileSystemProvider';
 
 export const registerVSCodeEventListeners = () => {
 	// replace current url when user change active editor
 	vscode.window.onDidChangeActiveTextEditor(async (editor) => {
-		const { owner, repo, ref, pageType, pullNumber } = await router.getState();
+		const { owner, repo, ref, pageType } = await router.getState();
 		const activeFileUri = editor?.document.uri;
 
-		if (activeFileUri?.scheme !== GitHub1sFileSearchProvider.scheme) {
+		// if no file opened and the branch is HEAD current,
+		// only retain `owner` and `repo` (and `ref` if need) in url
+		if (!activeFileUri) {
+			const browserPath =
+				ref.toUpperCase() === 'HEAD'
+					? `/${owner}/${repo}`
+					: `/${owner}/${repo}/tree/${ref}`;
+			router.history.replace(browserPath);
 			return;
 		}
 
-		// only `tree/blob` page will replace url with the active editor change
-		if ([PageType.TREE, PageType.BLOB].includes(pageType)) {
-			const filePath = activeFileUri?.path || '';
-			// if no file opened and the branch is HEAD current, only retain owner and repo in url
-			const browserPath =
-				!filePath && ref.toUpperCase() === 'HEAD'
-					? `/${owner}/${repo}`
-					: `/${owner}/${repo}/${filePath ? 'blob' : 'tree'}/${ref}${filePath}`;
-			router.history.replace(browserPath);
+		if (
+			// only `tree/blob` page will replace url with the active editor change
+			![PageType.TREE, PageType.BLOB].includes(pageType) ||
+			// only the file in explorer will change the router,
+			// the file in explorer will have a empty authority
+			activeFileUri?.authority ||
+			activeFileUri?.scheme !== GitHub1sFileSystemProvider.scheme
+		) {
+			return;
 		}
+
+		const browserPath = `/${owner}/${repo}/blob/${ref}${activeFileUri.path}`;
+		router.history.replace(browserPath);
 	});
 };

--- a/extensions/github1s/src/router/parser/commits.ts
+++ b/extensions/github1s/src/router/parser/commits.ts
@@ -1,0 +1,19 @@
+/**
+ * @file GitHub Commit List Url Parser
+ * @author netcon
+ */
+
+import { parsePath } from 'history';
+import { RouterState, PageType } from '../types';
+
+export const parseCommitsUrl = async (path: string): Promise<RouterState> => {
+	const pathParts = parsePath(path).pathname.split('/').filter(Boolean);
+	const [owner, repo, _pageType, ...branchParts] = pathParts;
+
+	return {
+		owner,
+		repo,
+		pageType: PageType.COMMIT_LIST,
+		ref: branchParts.length ? branchParts.join('/') : 'HEAD',
+	};
+};

--- a/extensions/github1s/src/router/parser/index.ts
+++ b/extensions/github1s/src/router/parser/index.ts
@@ -8,6 +8,7 @@ import { parseTreeUrl } from './tree';
 import { parseBlobUrl } from './blob';
 import { parsePullsUrl } from './pulls';
 import { parsePullUrl } from './pull';
+import { parseCommitsUrl } from './commits';
 import { parseCommitUrl } from './commit';
 import { PageType, RouterState } from '../types';
 
@@ -19,8 +20,7 @@ const detectPageTypeFromPathParts = (pathParts: string[]): PageType => {
 		pulls: PageType.PULL_LIST,
 		pull: PageType.PULL,
 		commit: PageType.COMMIT,
-		// TODO: implements below types
-		// commits: PageType.COMMIT_LIST,
+		commits: PageType.COMMIT_LIST,
 	};
 	return PAGE_TYPE_MAP[pathParts[2]] || PageType.TREE;
 };
@@ -40,6 +40,8 @@ export const parseGitHubUrl = async (path: string): Promise<RouterState> => {
 			return parsePullsUrl(path);
 		case PageType.COMMIT:
 			return parseCommitUrl(path);
+		case PageType.COMMIT_LIST:
+			return parseCommitsUrl(path);
 	}
 
 	// fallback to default


### PR DESCRIPTION
Bug: editor will close when open it at first time
Steps of recurrence:

1. Open https://github1s.com
2. Open any file, the editor will force closed at the first time

This is because we refresh the explorer state when the pageType changed. In fact the refresh action should not be occured when the pageType is become BLOB from TREE, vice versa. Sorry for my mistake.

https://github.com/conwnet/github1s/blob/bbc88fee5307a48128be0753f481c1b21a549b9b/extensions/github1s/src/listeners/router/explorer.ts#L19-L24

Another things is add the `commits` route support for GitHub.