### PR TITLE
fix: can not update data because of the fetch cache

### DIFF
--- a/extensions/github1s/src/helpers/fetch.ts
+++ b/extensions/github1s/src/helpers/fetch.ts
@@ -84,7 +84,6 @@ export const fetch = reuseable(async (url: string, options?: RequestInit) => {
 	try {
 		response = await self.fetch(url, {
 			mode: 'cors',
-			cache: 'force-cache',
 			...options,
 			headers: { ...authHeaders, ...customHeaders },
 		});


### PR DESCRIPTION
Now we use the `cache: 'force-cache'` as the default fetch cache option, which will break the data updating.

Steps to Reproduce:
1. Someone open `github1s.com` without login and met a RateLimit Error.
2. Provider an OAuth token Manual.
3. The user stil can't get the correct response.

