### PR TITLE
fix: the browser url changed in a wrong way

### DIFF
--- a/extensions/github1s/src/listeners/vscode.ts
+++ b/extensions/github1s/src/listeners/vscode.ts
@@ -14,25 +14,23 @@ export const registerVSCodeEventListeners = () => {
 		const { owner, repo, ref, pageType } = await router.getState();
 		const activeFileUri = editor?.document.uri;
 
-		// if no file opened and the branch is HEAD current,
-		// only retain `owner` and `repo` (and `ref` if need) in url
-		if (!activeFileUri) {
+		// only `tree/blob` page will replace url with the active editor change
+		if (![PageType.TREE, PageType.BLOB].includes(pageType)) {
+			return;
+		}
+
+		// if the file which not belong to current workspace is opened, or no file
+		// is opened, only retain `owner` and `repo` (and `ref` if need) in browser url
+		if (
+			!activeFileUri ||
+			activeFileUri?.authority ||
+			activeFileUri?.scheme !== GitHub1sFileSystemProvider.scheme
+		) {
 			const browserPath =
 				ref.toUpperCase() === 'HEAD'
 					? `/${owner}/${repo}`
 					: `/${owner}/${repo}/tree/${ref}`;
 			router.history.replace(browserPath);
-			return;
-		}
-
-		if (
-			// only `tree/blob` page will replace url with the active editor change
-			![PageType.TREE, PageType.BLOB].includes(pageType) ||
-			// only the file in explorer will change the router,
-			// the file in explorer will have a empty authority
-			activeFileUri?.authority ||
-			activeFileUri?.scheme !== GitHub1sFileSystemProvider.scheme
-		) {
 			return;
 		}
 


### PR DESCRIPTION
It is a bug:

Steps to Reproduce:

1. Open any request for example `https://github1s.com/conwnet/github1s/pull/265`
2. Switch to `Source Control Panel`
3. Open any file and close it (close all editors)
4. The url would changed to ~~`https://github1s.com/conwnet/github1s`~~ `https://github1s.com/conwnet/github1s/tree/17ba76f2293bc3db05c90174be0205d679703311` (it is wrong)

I am really sorry for that...🙏

