### PR TITLE
perf: optimizing the ref matching logic

### DIFF
--- a/extensions/github1s/src/router/parser/tree.ts
+++ b/extensions/github1s/src/router/parser/tree.ts
@@ -28,8 +28,15 @@ const detectRefFormPathParts = async (pathParts: string[]): Promise<string> => {
 	if (!pathParts[3] || pathParts[3].toUpperCase() === 'HEAD') {
 		return 'HEAD';
 	}
-	const branchRefs = await repository.getBranches();
-	const tagRefs = await repository.getTags();
+	// the ref will be pathParts[3] if there is no other parts after it
+	if (!pathParts[4]) {
+		return pathParts[3];
+	}
+	// use Promise.all to fetch all refs in parallel as soon as possible
+	const [branchRefs, tagRefs] = await Promise.all([
+		repository.getBranches(),
+		repository.getTags(),
+	]);
 	const refNames = [...branchRefs, ...tagRefs].map((item) => item.name);
 	// fallback to pathParts[3] because it also can be a commit ID
 	return findMatchedBranchOrTag(refNames, pathParts) || pathParts[3];


### PR DESCRIPTION
1. when user visit the url looks like `https://github1s.com/:owner/:repo/tree/:ref` and no other string after this, we can just assume the ref is `:ref`, fetch all branches/tags is not necessary.
2. `await` make the `getBranches` and `getTags` serially, we can use `Promise.all` to make it in parallel