### PR TITLE
fix: vscode-unpkg proxy miss necessary headers

### DIFF
--- a/api/vscode-unpkg/index.js
+++ b/api/vscode-unpkg/index.js
@@ -18,8 +18,15 @@ module.exports = async (req, res) => {
 	const publisher = matches[1];
 	const restPartsPath = matches[2];
 	const requestUrl = `https://${publisher}.vscode-unpkg.net/${publisher}/${restPartsPath}`;
-	const response = await got.get(requestUrl);
+	const responsePromise = got(requestUrl);
+	const bufferPromise = responsePromise.buffer();
+	const [response, buffer] = await Promise.all([
+		responsePromise,
+		bufferPromise,
+	]);
 
 	res.status(response.statusCode);
-	return res.send(response.body);
+	res.setHeader('cache-control', response.headers['cache-control']);
+	res.setHeader('content-type', response.headers['content-type']);
+	return res.send(buffer);
 };

--- a/api/vscode-unpkg/yarn.lock
+++ b/api/vscode-unpkg/yarn.lock
@@ -3,9 +3,9 @@
 
 
 "@sindresorhus/is@^4.0.0":
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.0.1.tgz#d26729db850fa327b7cacc5522252194404226f5"
-  integrity sha512-Qm9hBEBu18wt1PO2flE7LPb30BHMQt1eQgbV76YntdNk73XZGpn3izvGTYxbGgzXKgbCjiia0uxTd3aTNQrY/g==
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/@sindresorhus/is/-/is-4.1.0.tgz#3853c0c48b47f0ebcdd3cd9a66fdd0d277173e78"
+  integrity sha512-Cgva8HxclecUCmAImsWsbZGUh6p5DSzQ8l2Uzxuj9ANiD7LVhLM1UJ2hX/R2Y+ILpvqgW9QjmTCaBkXtj8+UOg==
 
 "@szmarczak/http-timer@^4.0.5":
   version "4.0.6"
@@ -30,16 +30,16 @@
   integrity sha512-SZs7ekbP8CN0txVG2xVRH6EgKmEm31BOxA07vkFaETzZz1xh+cbt8BcI0slpymvwhx5dlFnQG2rTlPVQn+iRPQ==
 
 "@types/keyv@*":
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.2.tgz#5d97bb65526c20b6e0845f6b0d2ade4f28604ee5"
-  integrity sha512-/FvAK2p4jQOaJ6CGDHJTqZcUtbZe820qIeTg7o0Shg7drB4JHeL+V/dhSaly7NXx6u8eSee+r7coT+yuJEvDLg==
+  version "3.1.3"
+  resolved "https://registry.yarnpkg.com/@types/keyv/-/keyv-3.1.3.tgz#1c9aae32872ec1f20dcdaee89a9f3ba88f465e41"
+  integrity sha512-FXCJgyyN3ivVgRoml4h94G/p3kY+u/B86La+QptcqJaWtBWtmc6TtkNfS40n9bIvyLteHh7zXOtgbobORKPbDg==
   dependencies:
     "@types/node" "*"
 
 "@types/node@*":
-  version "16.7.10"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.7.10.tgz#7aa732cc47341c12a16b7d562f519c2383b6d4fc"
-  integrity sha512-S63Dlv4zIPb8x6MMTgDq5WWRJQe56iBEY0O3SOFA9JrRienkOVDXSXBjjJw6HTNQYSE2JI6GMCR6LVbIMHJVvA==
+  version "16.9.1"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-16.9.1.tgz#0611b37db4246c937feef529ddcc018cf8e35708"
+  integrity sha512-QpLcX9ZSsq3YYUUnD3nFDY8H7wctAhQj/TFKL8Ya8v5fMm3CFXxo8zStsLAl780ltoYoo1WvKUVGBQK+1ifr7g==
 
 "@types/responselike@*", "@types/responselike@^1.0.0":
   version "1.0.0"

--- a/scripts/serve-dist.js
+++ b/scripts/serve-dist.js
@@ -8,17 +8,10 @@ const handler = require('serve-handler');
 const httpProxy = require('http-proxy');
 
 const APP_ROOT = path.join(__dirname, '..');
-const options = { public: path.join(APP_ROOT, 'dist'), cleanUrls: false };
-
-// now sourcegraph graphql api is refused the CORS check
-// just proxy the request to sourcegraph directly for a taste
-const sourcegraphProxy = httpProxy.createProxyServer({
-	target: 'https://sourcegraph.com/.api/graphql',
+const staticOptions = { public: path.join(APP_ROOT, 'dist'), cleanUrls: false };
+const proxyServer = httpProxy.createServer({
 	ignorePath: true,
 	changeOrigin: false,
-	headers: {
-		host: 'sourcegraph.com',
-	},
 });
 
 const handleProxyError = (error) => {
@@ -27,26 +20,25 @@ const handleProxyError = (error) => {
 	});
 	res.end(JSON.stringify({ message: error.message }));
 };
+proxyServer.on('error', handleProxyError);
 
+// now sourcegraph graphql api is refused the CORS check
+// just proxy the request to sourcegraph directly for a taste
 const sourcegraphProxyHandler = (req, res) => {
-	sourcegraphProxy.web(req, res);
-	sourcegraphProxy.on('error', handleProxyError);
+	const host = 'sourcegraph.com';
+	const target = `https://${host}/.api/graphql`;
+	const headers = { host };
+	proxyServer.web(req, res, { target, headers });
 };
 
 // proxy the request to vscode-unpkg.net
 const vscodeUnpkgProxyHandler = (req, res, vscodeUnpkgMatches) => {
 	const publisher = vscodeUnpkgMatches[1];
 	const restPartsPath = vscodeUnpkgMatches[2];
-	const host = `${publisher}.vscode-unpkg.net`;
-	const proxy = httpProxy.createServer({
-		target: `https://${host}/${publisher}/${restPartsPath}`,
-		ignorePath: true,
-		changeOrigin: false,
-		headers: { host },
-	});
-
-	proxy.web(req, res);
-	proxy.on('error', handleProxyError);
+	const host = `${publisher}.vscode-unpkg.net`.toLowerCase();
+	const target = `https://${host}/${publisher}/${restPartsPath}`;
+	const headers = { host };
+	proxyServer.web(req, res, { target, headers });
 };
 
 const server = http.createServer((request, response) => {
@@ -66,11 +58,11 @@ const server = http.createServer((request, response) => {
 		fs.constants.F_OK,
 		(error) => {
 			if (!error && urlObj.pathname !== '/') {
-				return handler(request, response, options);
+				return handler(request, response, staticOptions);
 			}
 			return handler(request, response, {
 				rewrites: [{ source: '*', destination: '/index.html' }],
-				...options,
+				...staticOptions,
 			});
 		}
 	);


### PR DESCRIPTION
Current vscode-unpkg proxy miss some necessary http headers, such like `content-type`, `cache-control`.

This will cause the images resource from vscode-unpkg can not display. 
