### PR TITLE
Support caching file tree

### DIFF
--- a/extensions/github1s/src/interfaces/github-api-rest.ts
+++ b/extensions/github1s/src/interfaces/github-api-rest.ts
@@ -44,13 +44,17 @@ const handleFileSystemRequestError = (error: RequestError) => {
 	);
 };
 
-export const readGitHubDirectory = (
+export const readGitHubDirectory = async (
 	owner: string,
 	repo: string,
 	ref: string,
 	path: string,
 	options?: RequestInit
 ) => {
+	const cached = await readGitHubDirectoryCached(owner, repo, ref, path);
+	if (cached) {
+		return cached;
+	}
 	return fetch(
 		`https://api.github.com/repos/${owner}/${repo}/git/trees/${ref}${encodeFilePath(
 			path
@@ -122,17 +126,21 @@ export const getGitHubTagRefs = (
 	});
 };
 
-export const getGitHubAllFiles = (
+export const getGitHubAllFiles = async (
 	owner: string,
 	repo: string,
 	ref: string,
 	path: string = '/'
 ) => {
-	return fetch(
+	const ret = await fetch(
 		`https://api.github.com/repos/${owner}/${repo}/git/trees/${ref}${encodeFilePath(
 			path
 		).replace(/^\//, ':')}?recursive=1`
 	).catch(handleFileSystemRequestError);
+	if (path === '/') {
+		populateFileTreeCache(owner, repo, ref, ret);
+	}
+	return ret;
 };
 
 export const getGitHubPulls = (
@@ -212,3 +220,150 @@ export const getGitHubCommitDetail = (
 		options
 	);
 };
+
+const repoFileTreeCacheKey = (owner: string, repo: string, ref: string) => {
+	return `${owner}/${repo}/${ref}`;
+};
+
+async function readGitHubDirectoryCached(
+	owner: string,
+	repo: string,
+	ref: string,
+	path: string,
+	options?: RequestInit
+): Promise<any | null> {
+	const cacheKey = repoFileTreeCacheKey(owner, repo, ref);
+	if (
+		!repoFileTreeCache.has(cacheKey) ||
+		repoFileTreeCache.get(cacheKey).expireTime < new Date()
+	) {
+		// also populate the cache
+		await getGitHubAllFiles(owner, repo, ref);
+	}
+	const cachedFileTree = repoFileTreeCache.get(cacheKey);
+	if (cachedFileTree.truncated) {
+		return null;
+	}
+
+	const nodeItselfAndChildren = cachedFileTree.fileTree.get(
+		path.substr(1, path.length - 1)
+	);
+
+	const children = nodeItselfAndChildren
+		.slice(1, nodeItselfAndChildren.length)
+		.map((child) => {
+			return path === '/'
+				? child
+				: {
+						// src/main -> main
+						path: child.path.substring(path.length, child.path.length),
+						mode: child.mode,
+						type: child.type,
+						sha: child.sha,
+						url: child.url,
+				  };
+		});
+
+	return {
+		sha: nodeItselfAndChildren[0].sha,
+		url: nodeItselfAndChildren[0].url,
+		truncated: false,
+		tree: [...children],
+	};
+}
+
+const repoFileTreeCache: Map<string, CacheEntry> = new Map();
+
+function populateFileTreeCache(
+	owner: string,
+	repo: string,
+	ref: string,
+	jsonObj: any
+) {
+	const cacheKey = repoFileTreeCacheKey(owner, repo, ref);
+	if (jsonObj.truncated) {
+		/*
+		https://docs.github.com/en/rest/reference/git#get-a-tree
+		If truncated is true in the response then the number of items in the tree array exceeded our maximum limit.
+		If you need to fetch more items, use the non-recursive method of fetching trees, and fetch one sub-tree at a time.
+		*/
+		repoFileTreeCache.set(cacheKey, {
+			owner,
+			repo,
+			ref,
+			sha: jsonObj.sha,
+			fileTree: new Map(),
+			url: jsonObj.url,
+			truncated: true,
+			expireTime: new Date(new Date().getTime() + 1000 * 3600 * 24 * 365),
+		});
+	} else {
+		// for SHA, never expires; otherwise 5 seconds expire time.
+		const expireTime = /^[0-9a-f]{40}$/.test(ref)
+			? new Date(new Date().getTime() + 1000 * 3600 * 24 * 365)
+			: new Date(new Date().getTime() + 5000);
+		repoFileTreeCache.set(cacheKey, {
+			owner,
+			repo,
+			ref,
+			sha: jsonObj.sha,
+			fileTree: createFileTree(jsonObj),
+			url: jsonObj.url,
+			truncated: false,
+			expireTime,
+		});
+	}
+}
+
+/**
+ * Key: the file path. "" for root path
+ * Value: [the node itself, ...the children of the path]
+ */
+function createFileTree(jsonObj: any): Map<string, GitTreeOrBlobObject[]> {
+	const all: GitTreeOrBlobObject[] = jsonObj.tree;
+	const ret = new Map();
+	all.forEach((item) => {
+		const pathSegments = item.path.split('/');
+		const parentPath = pathSegments.slice(0, pathSegments.length - 1).join('/');
+
+		if (ret.has(item.path)) {
+			ret.set(item.path, [item, ...ret.get(item.path)]);
+		} else {
+			ret.set(item.path, [item]);
+		}
+
+		if (!ret.has(parentPath)) {
+			ret.set(parentPath, []);
+		}
+		ret.get(parentPath).push(item);
+	});
+	// special handling for root node
+	ret.set('', [
+		new GitTreeOrBlobObject('', '', 'tree', jsonObj.sha, jsonObj.url),
+		...ret.get(''),
+	]);
+	return ret;
+}
+
+class CacheEntry {
+	constructor(
+		readonly owner: string,
+		readonly repo: string,
+		readonly ref: string,
+		readonly sha: string,
+		readonly fileTree: Map<string, GitTreeOrBlobObject[]>,
+		readonly url: string,
+		readonly truncated: boolean,
+		readonly expireTime: Date
+	) {}
+}
+
+class GitTreeOrBlobObject {
+	constructor(
+		readonly path: string,
+		readonly mode: string,
+		readonly type: string,
+		readonly sha: string,
+		readonly url: string
+	) {}
+}


### PR DESCRIPTION
Prior to this change, every `readGitHubDirectory` invokes GitHub API,
this is unnecessary because `getGitHubAllFiles` already returns
everything we need. This PR caches the whole file tree on
`getGitHubAllFiles` invocation and returns the proper result from
cache upon subsequent `readGitHubDirectory` invocation.

This saves a lot of GitHub API calls. Before:

![image](https://user-images.githubusercontent.com/12689835/140236449-d344d246-6857-4a3a-98f2-4e4043c8176e.png)

After:

![image](https://user-images.githubusercontent.com/12689835/140236344-c22867e5-b28a-4a3e-b1c5-36dfb4c2d33a.png)
