### PR TITLE
Fix debounce time

### DIFF
--- a/extensions/github1s/src/helpers/func.ts
+++ b/extensions/github1s/src/helpers/func.ts
@@ -49,7 +49,7 @@ export const debounce = <T extends (...args: any[]) => any>(
 	let timer = null;
 	return function (...args: Parameters<T>): void {
 		timer && clearTimeout(timer);
-		timer = setTimeout(() => func.call(this, ...args), timer);
+		timer = setTimeout(() => func.call(this, ...args), wait);
 	};
 };
 


### PR DESCRIPTION
`wait: number` is unused, and instead the timeout ID is passed to `setTimeout`. I guess this wasn't intentional.