### PR TITLE
Trace error before writing to response

### DIFF
--- a/scripts/serve-dist.js
+++ b/scripts/serve-dist.js
@@ -15,6 +15,7 @@ const proxyServer = httpProxy.createServer({
 });
 
 const handleProxyError = (error) => {
+	console.trace(error);
 	res.writeHead(500, {
 		'Content-Type': 'application/json',
 	});

--- a/scripts/serve-dist.js
+++ b/scripts/serve-dist.js
@@ -14,8 +14,12 @@ const proxyServer = httpProxy.createServer({
 	changeOrigin: false,
 });
 
-const handleProxyError = (error) => {
+const handleProxyError = (error, req, res) => {
 	console.trace(error);
+	res.writeHead(500, {
+		'Content-Type': 'application/json',
+	});
+	res.end(JSON.stringify({ message: error.message }));
 };
 proxyServer.on('error', handleProxyError);
 

--- a/scripts/serve-dist.js
+++ b/scripts/serve-dist.js
@@ -16,10 +16,6 @@ const proxyServer = httpProxy.createServer({
 
 const handleProxyError = (error) => {
 	console.trace(error);
-	res.writeHead(500, {
-		'Content-Type': 'application/json',
-	});
-	res.end(JSON.stringify({ message: error.message }));
 };
 proxyServer.on('error', handleProxyError);
 


### PR DESCRIPTION
In some cases the proxy exits because `res` is undefined:

```
/Users/zhb/Projects/ByteLegend/github1s/scripts/serve-dist.js:18
	res.writeHead(500, {
	^

ReferenceError: res is not defined
    at ProxyServer.handleProxyError (/Users/zhb/Projects/ByteLegend/github1s/scripts/serve-dist.js:18:2)
    at ProxyServer.emit (/Users/zhb/Projects/ByteLegend/github1s/node_modules/eventemitter3/index.js:210:27)
    at ClientRequest.proxyError (/Users/zhb/Projects/ByteLegend/github1s/node_modules/http-proxy/lib/http-proxy/passes/web-incoming.js:165:18)
    at ClientRequest.emit (events.js:400:28)
    at TLSSocket.socketCloseListener (_http_client.js:449:11)
    at TLSSocket.emit (events.js:412:35)
    at net.js:686:12
    at TCP.done (_tls_wrap.js:564:7)
error Command failed with exit code 1.
```