### PR TITLE
Fix up-to-date check issue in copy-extensions.sh

### DIFF
--- a/vscode-web-github1s/scripts/copy-extensions.sh
+++ b/vscode-web-github1s/scripts/copy-extensions.sh
@@ -3,14 +3,16 @@ set -euo pipefail
 
 cd "$(dirname "${0}")/.."
 APP_ROOT=$(pwd)
-
 function ensureBuiltinExtensitions() {
 	cd "${APP_ROOT}/lib/vscode"
-	if [ ! -e "extensions/emmet/dist/browser" ]
+	git diff --exit-code --name-only extensions
+	if [ $? != 0 ] || [ ! -e "extensions/emmet/dist/browser" ]
 	then
 		echo "compile vscode builtin extensions..."
 		yarn gulp compile-web
 		yarn gulp compile-extension-media
+	else
+		echo "vscode builtin extensions is up-to-date, skip compiling."
 	fi
 }
 
@@ -24,3 +26,4 @@ function main() {
 }
 
 main "$@"
+


### PR DESCRIPTION
Previously the script only check if `extensions/emmet/dist/browser`
exists, and skip compiling if so. This PR adds an extra `git diff`
check, and run compiling if there's any changes in `extensions`.