### PR TITLE
Fix copy extensions

### DIFF
--- a/vscode-web-github1s/scripts/copy-extensions.sh
+++ b/vscode-web-github1s/scripts/copy-extensions.sh
@@ -3,14 +3,16 @@ set -euo pipefail
 
 cd "$(dirname "${0}")/.."
 APP_ROOT=$(pwd)
-
 function ensureBuiltinExtensitions() {
 	cd "${APP_ROOT}/lib/vscode"
-	if [ ! -e "extensions/emmet/dist/browser" ]
+	git diff --exit-code --name-only extensions
+	if [ $? != 0 ] || [ ! -e "extensions/emmet/dist/browser" ]
 	then
 		echo "compile vscode builtin extensions..."
 		yarn gulp compile-web
 		yarn gulp compile-extension-media
+	else
+		echo "vscode builtin extensions is up-to-date, skip compiling."
 	fi
 }
 
@@ -24,3 +26,4 @@ function main() {
 }
 
 main "$@"
+

--- a/vscode-web-github1s/scripts/copy-extensions.sh
+++ b/vscode-web-github1s/scripts/copy-extensions.sh
@@ -5,8 +5,8 @@ cd "$(dirname "${0}")/.."
 APP_ROOT=$(pwd)
 function ensureBuiltinExtensitions() {
 	cd "${APP_ROOT}/lib/vscode"
-	git diff --exit-code --name-only extensions
-	if [ $? != 0 ] || [ ! -e "extensions/emmet/dist/browser" ]
+	EXTENSIONS_DIRTY=0 && git diff --exit-code --name-only extensions || EXTENSIONS_DIRTY=$?
+	if [ $EXTENSIONS_DIRTY != 0 ] || [ ! -e "extensions/emmet/dist/browser" ]
 	then
 		echo "compile vscode builtin extensions..."
 		yarn gulp compile-web


### PR DESCRIPTION
The fix in https://github.com/conwnet/github1s/pull/376 was not complete - because of `set -e` in `copy-extensions.sh`, the script will exit immediately when `git diff --exit-code --name-only extensions` returns non-zero. Fixed by using `||` to capture the exit code.

Verified locally.