### PR TITLE
feat: add search page type

### DIFF
--- a/extensions/github1s/src/adapters/github1s/parse-path.ts
+++ b/extensions/github1s/src/adapters/github1s/parse-path.ts
@@ -6,6 +6,7 @@
 import { parsePath } from 'history';
 import { PageType, RouterState } from '@/adapters/types';
 import { GitHub1sDataSource } from './data-source';
+import * as queryString from 'query-string';
 
 const parseTreeUrl = async (path: string): Promise<RouterState> => {
 	const pathParts = parsePath(path).pathname!.split('/').filter(Boolean);
@@ -81,6 +82,16 @@ const parsePullUrl = async (path: string): Promise<RouterState> => {
 	};
 };
 
+const parseSearchUrl = async (path: string): Promise<RouterState> => {
+	const { pathname, search } = parsePath(path);
+	const pathParts = pathname!.split('/').filter(Boolean);
+	const [owner, repo, _pageType] = pathParts;
+	const queryOptions = queryString.parse(search || '');
+	const query = typeof queryOptions.q === 'string' ? queryOptions.q : '';
+
+	return { repo: `${owner}/${repo}`, pageType: PageType.Search, ref: 'HEAD', query };
+};
+
 const PAGE_TYPE_MAP = {
 	tree: PageType.Tree,
 	blob: PageType.Blob,
@@ -88,6 +99,7 @@ const PAGE_TYPE_MAP = {
 	pull: PageType.CodeReview,
 	commit: PageType.Commit,
 	commits: PageType.CommitList,
+	search: PageType.Search,
 };
 
 export const parseGitHubPath = async (path: string): Promise<RouterState> => {
@@ -110,6 +122,8 @@ export const parseGitHubPath = async (path: string): Promise<RouterState> => {
 				return parseCommitUrl(path);
 			case PageType.CommitList:
 				return parseCommitsUrl(path);
+			case PageType.Search:
+				return parseSearchUrl(path);
 		}
 	}
 

--- a/extensions/github1s/src/adapters/github1s/parse-path.ts
+++ b/extensions/github1s/src/adapters/github1s/parse-path.ts
@@ -88,8 +88,23 @@ const parseSearchUrl = async (path: string): Promise<RouterState> => {
 	const [owner, repo, _pageType] = pathParts;
 	const queryOptions = queryString.parse(search || '');
 	const query = typeof queryOptions.q === 'string' ? queryOptions.q : '';
+	const isRegex = queryOptions.regex === 'yes';
+	const isCaseSensitive = queryOptions.case === 'yes';
+	const matchWholeWord = queryOptions.whole === 'yes';
+	const filesToInclude = typeof queryOptions['files-to-include'] === 'string' ? queryOptions['files-to-include'] : '';
+	const filesToExclude = typeof queryOptions['files-to-exclude'] === 'string' ? queryOptions['files-to-exclude'] : '';
 
-	return { repo: `${owner}/${repo}`, pageType: PageType.Search, ref: 'HEAD', query };
+	return {
+		repo: `${owner}/${repo}`,
+		pageType: PageType.Search,
+		ref: 'HEAD',
+		query,
+		isRegex,
+		isCaseSensitive,
+		matchWholeWord,
+		filesToInclude,
+		filesToExclude,
+	};
 };
 
 const PAGE_TYPE_MAP = {

--- a/extensions/github1s/src/adapters/types.ts
+++ b/extensions/github1s/src/adapters/types.ts
@@ -331,7 +331,15 @@ export type RouterState = { repo: string; ref: string } & (
 	| { pageType: PageType.Commit; commitSha: string } // for commit detail page
 	| { pageType: PageType.CodeReviewList } // for code review list page
 	| { pageType: PageType.CodeReview; codeReviewId: string }
-	| { pageType: PageType.Search; query: string }
+	| {
+			pageType: PageType.Search;
+			query?: string;
+			isRegex?: boolean;
+			isCaseSensitive?: boolean;
+			matchWholeWord?: boolean;
+			filesToInclude?: string;
+			filesToExclude?: string;
+	  }
 );
 
 export class RouterParser {

--- a/extensions/github1s/src/adapters/types.ts
+++ b/extensions/github1s/src/adapters/types.ts
@@ -317,6 +317,9 @@ export enum PageType {
 	// e.g. https://github.com/conwnet/github1s/blame/master/.gitignore
 	FileBlame = 'FileBlame',
 
+	// show search result
+	Search = 'Search',
+
 	// branches, tags, wiki, gist should be on the way
 	Unknown = 'Unknown',
 }
@@ -328,7 +331,8 @@ export type RouterState = { repo: string; ref: string } & (
 	| { pageType: PageType.Commit; commitSha: string } // for commit detail page
 	| { pageType: PageType.CodeReviewList } // for code review list page
 	| { pageType: PageType.CodeReview; codeReviewId: string }
-); // for code review detail page
+	| { pageType: PageType.Search; query: string }
+);
 
 export class RouterParser {
 	// parse giving path (starts with '/', may includes search and hash) to Router state,

--- a/extensions/github1s/src/extension.ts
+++ b/extensions/github1s/src/extension.ts
@@ -74,5 +74,7 @@ const initialVSCodeState = async () => {
 		vscode.commands.executeCommand('github1s.views.commitList.focus');
 	} else if ([PageType.CodeReview, PageType.Commit].includes(routerState.pageType)) {
 		vscode.commands.executeCommand('workbench.scm.focus');
+	} else if (routerState.pageType === PageType.Search) {
+		vscode.commands.executeCommand('workbench.action.findInFiles', { query: routerState.query });
 	}
 };

--- a/extensions/github1s/src/extension.ts
+++ b/extensions/github1s/src/extension.ts
@@ -75,6 +75,6 @@ const initialVSCodeState = async () => {
 	} else if ([PageType.CodeReview, PageType.Commit].includes(routerState.pageType)) {
 		vscode.commands.executeCommand('workbench.scm.focus');
 	} else if (routerState.pageType === PageType.Search) {
-		vscode.commands.executeCommand('workbench.action.findInFiles', { query: routerState.query });
+		vscode.commands.executeCommand('workbench.action.findInFiles', routerState);
 	}
 };


### PR DESCRIPTION
This PR resolves #428 

Supoort for **Search** Page Type, which corresponds to the GitHub's Repo Search Page. (https://github.com/conwnet/github1s/search?q=test)

For a preview: https://github1s-git-search-page-type-vscode-github1s.vercel.app/conwnet/github1s/search?q=test
