### PR TITLE
Update the "Stargazers over time" section, to get the chart displayed again

### DIFF
--- a/README.md
+++ b/README.md
@@ -162,7 +162,7 @@ We are partnered with [OSS Insight](https://ossinsight.io/?utm_source=github1s&u
 
 ## Stargazers over time
 
-[![Stargazers over time](https://starchart.cc/conwnet/github1s.svg)](https://starchart.cc/conwnet/github1s)
+[![Stargazers over time](https://api.star-history.com/svg?repos=conwnet/github1s&type=Date)](https://star-history.com/#conwnet/github1s&Date)
 
 <details>
 <summary>Third-party Related Projects</summary>


### PR DESCRIPTION
Replaces the image from `starchart.cc` (which is [not working anymore](https://starchart.cc/conwnet/github1)) with an image from `star-history.com`.

You can preview it [here](https://github.com/conwnet/github1s/blob/e6f610b34bb117fd6c29b80551965b2b473e6985/README.md#stargazers-over-time):

![image](https://user-images.githubusercontent.com/418083/211781851-061674d5-aa1a-4ce2-a531-ff546299ebe1.png)
