### PR TITLE
fix: quick diff  in commit/codereview pages

### DIFF
--- a/extensions/github1s/src/adapters/github1s/parse-path.ts
+++ b/extensions/github1s/src/adapters/github1s/parse-path.ts
@@ -77,7 +77,7 @@ const parsePullUrl = async (path: string): Promise<RouterState> => {
 	return {
 		repo: `${owner}/${repo}`,
 		pageType: PageType.CodeReview,
-		ref: codeReview.base.commitSha,
+		ref: codeReview.head.commitSha,
 		codeReviewId,
 	};
 };

--- a/extensions/github1s/src/changes/index.ts
+++ b/extensions/github1s/src/changes/index.ts
@@ -7,9 +7,11 @@ import * as vscode from 'vscode';
 import * as adapterTypes from '@/adapters/types';
 import { GitHub1sQuickDiffProvider } from './quick-diff';
 import { getChangedFileDiffCommand, getChangedFiles } from './files';
+import adapterManager from '@/adapters/manager';
 
 export const updateSourceControlChanges = (() => {
-	const sourceControl = vscode.scm.createSourceControl('github1s', 'GitHub1s');
+	const rootUri = vscode.Uri.parse('').with({ scheme: adapterManager.getCurrentScheme() });
+	const sourceControl = vscode.scm.createSourceControl('github1s', 'GitHub1s', rootUri);
 	const changesGroup = sourceControl.createResourceGroup('changes', 'Changes');
 	sourceControl.quickDiffProvider = new GitHub1sQuickDiffProvider();
 


### PR DESCRIPTION
<img width="684" alt="image" src="https://user-images.githubusercontent.com/17734694/213403977-48b6df64-280b-4213-88b2-5ac7877e00b2.png">

make [quick diff](https://code.visualstudio.com/api/extension-guides/scm-provider#quick-diff) work in commit/pull request pages.
