### PR TITLE
feat: support gitlab personal repo

### DIFF
--- a/extensions/github1s/assets/pages/github1s-settings.js
+++ b/extensions/github1s/assets/pages/github1s-settings.js
@@ -28,13 +28,38 @@ const ConnectToGitHubBlock = (props) => {
 	`;
 };
 
-const ManualInputTokenBlock = ({ onTokenChange, ...props }) => {
-	const createTokenLink = 'https://github.com/settings/tokens/new?scopes=repo&description=GitHub1s';
+const ConnectToGitLabBlock = (props) => {
+	const [loading, setLoading] = useState(false);
+	const handleButtonClick = useCallback(() => {
+		setLoading(true);
+		postMessage('connect-to-gitlab').then(() => setLoading(false));
+	}, []);
+
+	return html`
+		<div class="authentication-method-block" ...${props}>
+			<h3 class="authentication-method-title">Authenticating OAuth App</h3>
+			<div class="flex-line">
+				<${VscodeButton} loading=${loading} onClick=${handleButtonClick}>Connect to GitLab<//>
+			</div>
+		</div>
+	`;
+};
+
+const ManualInputTokenBlock = ({ onTokenChange, isGitLab, ...props }) => {
+	const [createTokenLink, setCreateTokenLink] = useState(
+		'https://github.com/settings/tokens/new?scopes=repo&description=GitHub1s'
+	);
 	const [inputToken, setInputToken] = useState('');
 	const [loading, setLoading] = useState(false);
 	const handleInputTokenChange = useCallback((event) => {
 		setInputToken(event.target.value);
 	}, []);
+
+	useEffect(() => {
+		if (isGitLab) {
+			setCreateTokenLink(GITLAB_DOMAIN + GITLAB_CREATE_TOKEN_URL + '?scopes=api&name=GitLab1s');
+		}
+	}, [isGitLab]);
 
 	const handleSubmit = useCallback(() => {
 		if (inputToken) {
@@ -74,13 +99,17 @@ const ManualInputTokenBlock = ({ onTokenChange, ...props }) => {
 
 const TokenEditPage = ({ token, onCancel, ...props }) => {
 	const cancelButton = token ? html`<${VscodeButton} onClick=${onCancel}>Cancel<//>` : '';
+	const [isGitLab, setIsGitLab] = useState(false);
+	useEffect(() => {
+		setIsGitLab(document.title.includes('GitLab1s'));
+	}, []);
 
 	return html`
 		<div class="token-edit-page" ...${props}>
 			<div class="page-title">Set AccessToken</div>
 			<${EditTokenDescription} />
-			<${ConnectToGitHubBlock} />
-			<${ManualInputTokenBlock} />
+			${isGitLab ? html`<${ConnectToGitLabBlock} />` : html`<${ConnectToGitHubBlock} />`}
+			<${ManualInputTokenBlock} isGitLab=${isGitLab} />
 			<div class="flex-line">${cancelButton}</div>
 		</div>
 	`;

--- a/extensions/github1s/assets/pages/gitlab1s-authentication.js
+++ b/extensions/github1s/assets/pages/gitlab1s-authentication.js
@@ -1,0 +1,228 @@
+import { render } from './preact.module.js';
+import { useState, useCallback, useEffect } from './preact-hooks.module.js';
+import { html, VscodeButton, VscodeInput, VscodeLoading, VscodeLink, postMessage } from './components.js';
+
+const AuthenticationFeatures = () => {
+	return html`
+		<ul class="authentication-features">
+			<li class="feature-item">
+				<a class="link" href="https://docs.gitlab.com/ee/api/#authentication" target="_blank"
+					>Access GitLab personal repository</a
+				>
+			</li>
+			<li class="feature-item">
+				<a
+					class="link"
+					href="https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits"
+					target="_blank"
+					>Higher rate rimit for GitLab official API</a
+				>
+			</li>
+		</ul>
+	`;
+};
+
+const AuthenticationButton = (props) => {
+	const [authenticating, setAuthenticating] = useState(false);
+
+	const handleButtonClick = useCallback(() => {
+		setAuthenticating(true);
+		postMessage('connect-to-gitlab').then(() => setAuthenticating(false));
+	}, []);
+
+	return html`
+		<button class="authentication-button" disabled="${authenticating}" onClick=${handleButtonClick} ...${props}>
+			<svg
+				class="github-logo"
+				height="32"
+				viewBox="65.72 65.72 368.55 368.55"
+				xmlns="http://www.w3.org/2000/svg"
+				style="padding: 9px;"
+			>
+				<path
+					d="m365.32 272.52-31.561-108.04c-1.968-5.944-6.688-9.935-12.999-9.935-6.312 0-11.437 3.584-13.405 9.527l-20.905 62.76h-72.933l-20.905-62.731c-1.968-5.942-7.093-9.528-13.406-9.528-6.311 0-11.435 3.963-12.999 9.937l-31.53 108.01c-1.188 3.964 0.405 8.333 3.562 10.722l111.58 84.204 111.96-84.204c3.127-2.359 4.719-6.731 3.533-10.722z"
+				/>
+				<path
+					d="m250 65.722c-101.62 0-184.28 82.661-184.28 184.28 0 101.62 82.662 184.28 184.28 184.28s184.28-82.663 184.28-184.28c0-101.62-82.659-184.28-184.28-184.28zm0 30.712c85 0 153.56 68.564 153.56 153.56 0 84.999-68.564 153.56-153.56 153.56-85.001 0-153.56-68.565-153.56-153.56 0-85.001 68.564-153.56 153.56-153.56z"
+				/>
+			</svg>
+			<span>${props.children}</span>
+		</button>
+	`;
+};
+
+const ManualInputToken = () => {
+	const createTokenLink = GITLAB_DOMAIN + GITLAB_CREATE_TOKEN_URL + '?scopes=read_api&name=GitLab1s';
+	const [inputToken, setInputToken] = useState('');
+	const [loading, setLoading] = useState(false);
+	const handleInputTokenChange = useCallback((event) => {
+		setInputToken(event.target.value);
+	}, []);
+
+	const handleSubmit = useCallback(() => {
+		if (inputToken) {
+			setLoading(true);
+			postMessage('validate-token', inputToken).then((tokenStatus) => {
+				if (!tokenStatus) {
+					const messageArgs = { level: 'info', args: ['This AccessToken is invalid'] };
+					postMessage('call-vscode-message-api', messageArgs);
+					setLoading(false);
+					return;
+				}
+				postMessage('set-token', inputToken).then(() => setLoading(false));
+			});
+		}
+	}, [inputToken]);
+
+	return html`
+		<div class="authentication-token">
+			<div class="token-input-line">
+				<${VscodeInput}
+					autocomplete="off"
+					value=${inputToken}
+					disabled="${loading}"
+					onInput=${handleInputTokenChange}
+				/>
+				<${VscodeButton} loading=${loading} onClick=${handleSubmit}>Submit<//>
+			</div>
+			<${VscodeLink} to="${createTokenLink}" external>Create New AccessToken<//>
+		</div>
+	`;
+};
+
+const SplitLine = () => {
+	return html`<div class="split-line"></div>`;
+};
+
+const AuthenticationFooter = () => {
+	return html`
+		<div class="authentication-footer">
+			<div>The access token will only store in your browser.</div>
+			<div>Don't forget to clean it while you are using a device that doesn't belong to you.</div>
+		</div>
+	`;
+};
+
+const AuthenticationForm = (props) => {
+	return html`
+		<div class="authentication-form">
+			<div class="form-title">${props.title || 'Authenticating to GitLab'}</div>
+			<${AuthenticationFeatures} />
+			<div class="form-content">
+				<${AuthenticationButton}>Connect to GitLab<//>
+				<${SplitLine} />
+				<${ManualInputToken} />
+			</div>
+		</div>
+	`;
+};
+
+const StatusNumberText = ({ count }) => {
+	if (count <= 0) {
+		return html`<span class="error-text">${count}</span>`;
+	}
+	if (count <= 99) {
+		return html`<span class="warning-text">${count}</span>`;
+	}
+
+	return html`<span class="success-text">${count}</span>`;
+};
+
+const AuthenticationDetail = ({ accessToken }) => {
+	const ratteLimitDocumentationLink =
+		'https://docs.gitlab.com/ee/user/gitlab_com/index.html#gitlabcom-specific-rate-limits';
+	const [tokenStatus, setTokenStatus] = useState(null);
+
+	const handleRefreshTokenStatus = useCallback(() => {
+		postMessage('validate-token', accessToken).then((tokenStatus) => {
+			setTokenStatus(tokenStatus || { invalid: true });
+		});
+	}, [accessToken]);
+
+	const handleClearToken = useCallback(() => {
+		postMessage('call-vscode-message-api', {
+			level: 'warning',
+			args: ['Would you want to clear the saved GitLab AccessToken?', { modal: true }, 'Confirm'],
+		}).then((choose) => choose === 'Confirm' && postMessage('set-token', ''));
+	}, []);
+
+	useEffect(() => {
+		handleRefreshTokenStatus();
+	}, [handleRefreshTokenStatus]);
+
+	if (!tokenStatus) {
+		return html`<${VscodeLoading} />`;
+	}
+
+	return html`
+		<div class="authentication-detail">
+			<div class="detail-title">Access Token Info</div>
+			<div class="token-status">
+				<div class="status-title">
+					<span>Rate Limit Info: </span>
+					<span class="refresh-button" onClick=${handleRefreshTokenStatus}>↻</span>
+				</div>
+				<ul class="rate-limit-info">
+					${tokenStatus.invalid ? html`<li>Token Status: <span class="error-text">invalid</span></li>` : ''}
+					<li>------------------------------</li>
+					<li>X-RateLimit-Limit: <${StatusNumberText} count=${tokenStatus.ratelimitLimit} /></li>
+					<li>X-RateLimit-Remaining: <${StatusNumberText} count=${tokenStatus.ratelimitRemaining} /></li>
+					<li>X-RateLimit-Used: ${tokenStatus.ratelimitUsed}</li>
+					<li>X-RateLimit-Reset: ${tokenStatus.ratelimitReset}</li>
+					<li>------------------------------</li>
+					<li class="rate-limit-description">
+						<span>Current rate limit window will reset after </span>
+						<span>${Math.max(tokenStatus.ratelimitReset - Math.ceil(Date.now() / 1000), 0)}s</span>
+					</li>
+					<li>
+						<a href=${ratteLimitDocumentationLink} target="_blank">GitLab Rate limiting Documentation</a>
+					</li>
+				</ul>
+			</div>
+			<div class="token-operations">
+				<${VscodeButton} size="middle" onClick=${handleClearToken}>Clear Access Token<//>
+			</div>
+		</div>
+	`;
+};
+
+const App = () => {
+	const [loading, setLoading] = useState(true);
+	const [accessToken, setAccessToken] = useState('');
+	const [notice, setNotice] = useState('');
+
+	useEffect(() => {
+		postMessage('get-token').then((token) => {
+			setAccessToken(token);
+			setLoading(false);
+		});
+		postMessage('get-notice').then((notice) => setNotice(notice));
+	}, []);
+
+	useEffect(() => {
+		const handler = ({ data }) => {
+			if (data.type === 'token-changed') {
+				setAccessToken(data.token);
+				postMessage('get-notice').then((notice) => setNotice(notice));
+			}
+		};
+		window.addEventListener('message', handler);
+		return () => window.removeEventListener('message', handler);
+	}, [setAccessToken]);
+
+	if (loading) {
+		return html`<${VscodeLoading} />`;
+	}
+
+	return html`
+		<div class="authentication-page">
+			${notice ? html`<div class="page-notice">${notice}</div>` : null}
+			<${accessToken ? AuthenticationDetail : AuthenticationForm} accessToken=${accessToken} />
+			<${AuthenticationFooter} />
+		</div>
+	`;
+};
+
+const loadingElement = document.getElementById('page-loading');
+loadingElement.parentNode.removeChild(loadingElement);
+render(html`<${App} />`, document.getElementById('app'));

--- a/extensions/github1s/extension.webpack.config.js
+++ b/extensions/github1s/extension.webpack.config.js
@@ -61,6 +61,12 @@ module.exports = /** @type WebpackConfig */ {
 	},
 	devtool: 'source-map',
 	plugins: [
+		new webpack.DefinePlugin({
+			GITLAB_DOMAIN: JSON.stringify(process.env.GITLAB_DOMAIN || 'https://gitlab.com'),
+			GITLAB_CREATE_TOKEN_URL: JSON.stringify(
+				process.env.GITLAB_CREATE_TOKEN_URL || '/-/profile/personal_access_tokens'
+			),
+		}),
 		new webpack.ProvidePlugin({
 			process: 'process/browser.js',
 		}),

--- a/extensions/github1s/package.json
+++ b/extensions/github1s/package.json
@@ -33,6 +33,11 @@
           "id": "github1s",
           "title": "GitHub1s",
           "icon": "assets/github1s.svg"
+        },
+        {
+          "id": "gitlab1s",
+          "title": "GitLab1s",
+          "icon": "assets/github1s.svg"
         }
       ]
     },
@@ -43,6 +48,14 @@
           "name": "Settings",
           "type": "webview",
           "when": "github1s:views:settings:visible == true"
+        }
+      ],
+      "gitlab1s": [
+        {
+          "id": "gitlab1s.views.settings",
+          "name": "Settings",
+          "type": "webview",
+          "when": "gitlab1s:views:settings:visible == true"
         }
       ],
       "scm": [

--- a/extensions/github1s/src/adapters/gitlab1s/authentication.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/authentication.ts
@@ -1,0 +1,111 @@
+/**
+ * @file github authentication page
+ * @author netcon
+ */
+
+import { Barrier } from '@/helpers/async';
+import { getExtensionContext } from '@/helpers/context';
+import * as vscode from 'vscode';
+import { GitLabTokenManager } from './token';
+import { createPageHtml, getWebviewOptions } from '@/helpers/page';
+import { messageApiMap } from './settings';
+
+export class GitLab1sAuthenticationView {
+	private static instance: GitLab1sAuthenticationView | null = null;
+	public static viewType = 'github1s.views.github1s-authentication';
+	private webviewPanel: vscode.WebviewPanel | null = null;
+	// using for waiting token
+	private tokenBarrier: Barrier | null = null;
+	// using for displaying open page reason
+	private notice: string = '';
+
+	private constructor() {}
+
+	public static getInstance(): GitLab1sAuthenticationView {
+		if (GitLab1sAuthenticationView.instance) {
+			return GitLab1sAuthenticationView.instance;
+		}
+		return (GitLab1sAuthenticationView.instance = new GitLab1sAuthenticationView());
+	}
+
+	private registerListeners() {
+		if (!this.webviewPanel) {
+			throw new Error('webview is not inited yet');
+		}
+		const tokenManager = GitLabTokenManager.getInstance();
+
+		this.webviewPanel.webview.onDidReceiveMessage((message) => {
+			const commonResponse = { id: message.id, type: message.type };
+			const postMessage = (data?: unknown) => this.webviewPanel!.webview.postMessage({ ...commonResponse, data });
+
+			switch (message.type) {
+				case 'get-notice':
+					postMessage(this.notice);
+					break;
+				case 'get-token':
+					postMessage(tokenManager.getToken());
+					break;
+				case 'set-token':
+					message.data && (this.notice = '');
+					tokenManager.setToken(message.data || '').then(() => postMessage());
+					break;
+				case 'validate-token':
+					tokenManager.validateToken(message.data).then((tokenStatus) => postMessage(tokenStatus));
+					break;
+				case 'connect-to-gitlab':
+					vscode.commands.executeCommand('github1s.commands.vscode.connectToGitLab').then((data: any) => {
+						if (data && data.error_description) {
+							vscode.window.showErrorMessage(data.error_description);
+						} else if (data && data.access_token) {
+							tokenManager.setToken(data.access_token || '').then(() => postMessage());
+						}
+						postMessage();
+					});
+					break;
+				case 'call-vscode-message-api':
+					const messageApi = messageApiMap[message.data?.level];
+					messageApi && messageApi(...message.data?.args).then((response) => postMessage(response));
+					break;
+			}
+		});
+
+		tokenManager.onDidChangeToken((token) => {
+			this.tokenBarrier && this.tokenBarrier.open();
+			this.tokenBarrier && (this.tokenBarrier = null);
+			this.webviewPanel?.webview.postMessage({ type: 'token-changed', token });
+		});
+	}
+
+	public open(notice: string = '', withBarriar = false) {
+		const extensionContext = getExtensionContext();
+		this.notice = notice;
+		withBarriar && !this.tokenBarrier && (this.tokenBarrier = new Barrier(600 * 1000));
+
+		if (!this.webviewPanel) {
+			this.webviewPanel = vscode.window.createWebviewPanel(
+				GitLab1sAuthenticationView.viewType,
+				'Authenticating to GitLab',
+				vscode.ViewColumn.One,
+				getWebviewOptions(extensionContext.extensionUri)
+			);
+			this.registerListeners();
+			this.webviewPanel.onDidDispose(() => (this.webviewPanel = null));
+		}
+
+		const styles = [
+			vscode.Uri.joinPath(extensionContext.extensionUri, 'assets/pages/components.css').toString(),
+			vscode.Uri.joinPath(extensionContext.extensionUri, 'assets/pages/github1s-authentication.css').toString(),
+		];
+		const script = Buffer.from(
+			`window.GITLAB_DOMAIN='${GITLAB_DOMAIN}';window.GITLAB_CREATE_TOKEN_URL='${GITLAB_CREATE_TOKEN_URL}'`
+		);
+		const scripts = [
+			'data:text/javascript;base64,' + script.toString('base64'),
+			vscode.Uri.joinPath(extensionContext.extensionUri, 'assets/pages/gitlab1s-authentication.js').toString(),
+		];
+
+		const webview = this.webviewPanel.webview;
+		webview.html = createPageHtml('Authenticating To GitLab', styles, scripts);
+		return withBarriar ? this.tokenBarrier!.wait() : Promise.resolve();
+	}
+}

--- a/extensions/github1s/src/adapters/gitlab1s/data-source.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/data-source.ts
@@ -1,0 +1,561 @@
+/**
+ * @file gitlab1s data-source-provider
+ * @author netcon
+ */
+
+import {
+	Branch,
+	CodeReview,
+	CodeReviewState,
+	TextSearchOptions,
+	Commit,
+	CommonQueryOptions,
+	DataSource,
+	Directory,
+	DirectoryEntry,
+	File,
+	BlameRange,
+	FileType,
+	Tag,
+	TextSearchResults,
+	TextSearchQuery,
+	SymbolDefinitions,
+	SymbolReferences,
+	FileChangeStatus,
+	ChangedFile,
+	SymbolHover,
+	CommitsQueryOptions,
+	CodeReviewsQueryOptions,
+} from '../types';
+import { toUint8Array } from 'js-base64';
+import { matchSorter } from 'match-sorter';
+// import { FILE_BLAME_QUERY } from './graphql';
+import { GitLabFetcher } from './fetcher';
+import { SourcegraphDataSource } from '../sourcegraph/data-source';
+
+const parseRepoFullName = (repoFullName: string) => {
+	const [owner, repo] = repoFullName.split('/');
+	return { owner, repo };
+};
+
+const encodeFilePath = (filePath: string): string => {
+	const pathParts = filePath.split('/').filter(Boolean);
+	return pathParts.map((segment) => encodeURIComponent(segment)).join('/');
+};
+
+const FileTypeMap = {
+	blob: FileType.File,
+	tree: FileType.Directory,
+	commit: FileType.Submodule,
+};
+
+const getPullState = (pull: { state: string; merged_at: string | null }): CodeReviewState => {
+	// current pull request is open
+	if (pull.state === 'opened') {
+		return CodeReviewState.Open;
+	}
+	// current pull request is merged
+	if (pull.state === 'closed' && pull.merged_at) {
+		return CodeReviewState.Merged;
+	}
+	// current pull is closed
+	return CodeReviewState.Merged;
+};
+
+const sourcegraphDataSource = SourcegraphDataSource.getInstance('gitlab');
+const trySourcegraphApiFirst = (_target: any, propertyKey: string, descriptor: PropertyDescriptor) => {
+	const originalMethod = descriptor.value;
+
+	descriptor.value = async function <T extends (...args) => Promise<any>>(...args: Parameters<T>) {
+		// return originalMethod.apply(this, args);
+		const githubFetcher = GitLabFetcher.getInstance();
+		if (await githubFetcher.useSourcegraphApiFirst(args[0])) {
+			try {
+				return await sourcegraphDataSource[propertyKey](...args);
+			} catch (e) {}
+		}
+		return originalMethod.apply(this, args);
+	};
+};
+
+export class GitLab1sDataSource extends DataSource {
+	private static instance: GitLab1sDataSource | null = null;
+	private branchesPromiseMap: Map<string, Promise<Branch[]>> = new Map();
+	private tagsPromiseMap: Map<string, Promise<Tag[]>> = new Map();
+	private refPathPromiseMap: Map<string, Promise<{ ref: string; path: string }>> = new Map();
+	private matchedRefsMap = new Map<string, string[]>();
+	private avatarPromiseMap = new Map<string, Promise<string>>();
+
+	public static getInstance(): GitLab1sDataSource {
+		if (GitLab1sDataSource.instance) {
+			return GitLab1sDataSource.instance;
+		}
+		return (GitLab1sDataSource.instance = new GitLab1sDataSource());
+	}
+
+	async provideRepository(repoFullName: string) {
+		if (!this.branchesPromiseMap.has(repoFullName)) {
+			await this.provideBranches(repoFullName);
+		}
+		return this.branchesPromiseMap.get(repoFullName)?.then((branches) => {
+			const defaultBranch = branches.find((br) => br.isDefault);
+			if (defaultBranch) {
+				return { name: defaultBranch.name, defaultBranch: defaultBranch?.name };
+			}
+		});
+	}
+
+	@trySourcegraphApiFirst
+	async provideDirectory(repoFullName: string, ref: string, path: string, recursive = false): Promise<Directory> {
+		const fetcher = GitLabFetcher.getInstance();
+		const encodedPath = encodeFilePath(path);
+		let page = 1;
+		let files = [];
+		const parseTreeItem = (treeItem): DirectoryEntry => ({
+			path: treeItem.path,
+			type: FileTypeMap[treeItem.type] || FileType.File,
+			commitSha: FileTypeMap[treeItem.id] === FileType.Submodule ? treeItem.sha || 'HEAD' : undefined,
+			size: treeItem.size,
+		});
+		while (page > 0) {
+			const requestParams = {
+				ref,
+				page,
+				path: encodedPath,
+				...parseRepoFullName(repoFullName),
+			};
+			const { data, headers } = await fetcher.request(
+				'GET /projects/{owner}%2F{repo}/repository/tree?recursive=true&per_page=100&page={page}&ref={ref}',
+				requestParams
+			);
+			files = files.concat(data);
+			page = Number(headers!.get('x-next-page'));
+		}
+
+		return {
+			entries: files.map(parseTreeItem),
+			truncated: false,
+		};
+	}
+
+	@trySourcegraphApiFirst
+	async provideFile(repoFullName: string, ref: string, path: string): Promise<File> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const requestParams = { owner, repo, ref, path: encodeURIComponent(path) };
+		const { data } = await fetcher.request(
+			'GET /projects/{owner}%2F{repo}/repository/files/{path}?ref={ref}',
+			requestParams
+		);
+		return { content: toUint8Array((data as any).content) };
+	}
+
+	@trySourcegraphApiFirst
+	async getBranches(repoFullName: string, ref: 'heads' | 'tags'): Promise<Branch[] | Tag[]> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const requestParams = { owner, repo, ref };
+		const { data } = await fetcher.request('GET /projects/{owner}%2F{repo}/repository/branches', requestParams);
+		return data.map((item) => ({
+			name: item.name,
+			commitSha: item.commit.id,
+			description: `${ref === 'heads' ? 'Branch' : 'Tag'} at ${item.commit.short_id}`,
+			isDefault: item.default,
+		}));
+	}
+
+	@trySourcegraphApiFirst
+	async getTags(repoFullName: string, ref: 'heads' | 'tags'): Promise<Branch[] | Tag[]> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const requestParams = { owner, repo, ref };
+		const { data } = await fetcher.request('GET /projects/{owner}%2F{repo}/repository/tags', requestParams);
+		return data.map((item) => ({
+			name: item.name,
+			commitSha: item.commit.id,
+			description: `${ref === 'heads' ? 'Branch' : 'Tag'} at ${item.commit.short_id}`,
+		}));
+	}
+
+	// @trySourcegraphApiFirst
+	// async extractRefPath(repoFullName: string, refAndPath: string): Promise<{ ref: string; path: string }> {
+	// 	if (!this.matchedRefsMap.has(repoFullName)) {
+	// 		this.matchedRefsMap.set(repoFullName, []);
+	// 	}
+	// 	const matchPathRef = (ref) => refAndPath.startsWith(`${ref}/`) || refAndPath === ref;
+	// 	const matchedRef = this.matchedRefsMap.get(repoFullName)?.find(matchPathRef);
+	// 	if (matchedRef) {
+	// 		return { ref: matchedRef, path: refAndPath.slice(matchedRef.length + 1) };
+	// 	}
+	// 	const mapKey = `${repoFullName} ${refAndPath}`;
+	// 	if (!this.refPathPromiseMap.has(mapKey)) {
+	// 		const refPathPromise = new Promise<{ ref: string; path: string }>(async (resolve, reject) => {
+	// 			if (!refAndPath || refAndPath.match(/^HEAD(\/.*)?$/i)) {
+	// 				return resolve({ ref: 'HEAD', path: refAndPath.slice(5) });
+	// 			}
+
+	// 			const fetcher = GitHubFetcher.getInstance();
+	// 			const { owner, repo } = parseRepoFullName(repoFullName);
+	// 			const requestParams = { owner, repo, refAndPath };
+	// 			const requestUrl = `GET /projects/{owner}%2F{repo}/git/extract-ref/{refAndPath}`;
+	// 			const response = await fetcher.request(requestUrl, requestParams).catch(reject);
+	// 			response?.data?.ref && this.matchedRefsMap.get(repoFullName)?.push(response.data.ref);
+	// 			return resolve(response?.data || { ref: 'HEAD', path: '' });
+	// 		});
+	// 		this.refPathPromiseMap.set(mapKey, refPathPromise);
+	// 	}
+	// 	return this.refPathPromiseMap.get(mapKey)!;
+	// }
+
+	@trySourcegraphApiFirst
+	async extractRefPath(repoFullName: string, refAndPath: string): Promise<{ ref: string; path: string }> {
+		if (!refAndPath || refAndPath.match(/^HEAD(\/.*)?$/i)) {
+			return { ref: 'HEAD', path: refAndPath.slice(5) };
+		}
+		if (!this.matchedRefsMap.has(repoFullName)) {
+			this.matchedRefsMap.set(repoFullName, []);
+		}
+		const matchPathRef = (ref) => refAndPath.startsWith(`${ref}/`) || refAndPath === ref;
+		const pathRef = this.matchedRefsMap.get(repoFullName)?.find(matchPathRef);
+		if (pathRef) {
+			return { ref: pathRef, path: refAndPath.slice(pathRef.length + 1) };
+		}
+		const [branches, tags] = await this.prepareAllRefs(repoFullName);
+		const exactRef = [...branches, ...tags].map((item) => item.name).find(matchPathRef);
+		const ref = exactRef || refAndPath.split('/')[0] || 'HEAD';
+		exactRef && this.matchedRefsMap.get(repoFullName)?.push(ref);
+		return { ref, path: refAndPath.slice(ref.length + 1) };
+	}
+
+	async prepareAllRefs(repoFullName: string) {
+		return Promise.all([this.provideBranches(repoFullName), this.provideTags(repoFullName)]);
+	}
+
+	@trySourcegraphApiFirst
+	async provideBranches(repoFullName: string, options?: CommonQueryOptions): Promise<Branch[]> {
+		if (!this.branchesPromiseMap.has(repoFullName)) {
+			this.branchesPromiseMap.set(repoFullName, this.getBranches(repoFullName, 'heads'));
+		}
+		return this.branchesPromiseMap.get(repoFullName)!.then((branches) => {
+			const matchOptions = { keys: ['name'] };
+			const matchedBranches = options?.query ? matchSorter(branches, options.query, matchOptions) : branches;
+			if (options?.pageSize) {
+				const page = options.page || 1;
+				const pageSize = options.pageSize;
+				return matchedBranches.slice(pageSize * (page - 1), pageSize * page);
+			}
+			return matchedBranches;
+		});
+	}
+
+	@trySourcegraphApiFirst
+	async provideBranch(repoFullName: string, branchName: string): Promise<Branch | null> {
+		const branches = await this.provideBranches(repoFullName);
+		return branches.find((item) => item.name === branchName) || null;
+	}
+
+	@trySourcegraphApiFirst
+	async provideTags(repoFullName: string, options?: CommonQueryOptions): Promise<Tag[]> {
+		if (!this.tagsPromiseMap.has(repoFullName)) {
+			this.tagsPromiseMap.set(repoFullName, this.getTags(repoFullName, 'tags'));
+		}
+		return this.tagsPromiseMap.get(repoFullName)!.then((tags) => {
+			const matchOptions = { keys: ['name'] };
+			const matchedTags = options?.query ? matchSorter(tags, options.query, matchOptions) : tags;
+			if (options?.pageSize) {
+				const page = options.page || 1;
+				const pageSize = options.pageSize;
+				return matchedTags.slice(pageSize * (page - 1), pageSize * page);
+			}
+			return matchedTags;
+		});
+	}
+
+	@trySourcegraphApiFirst
+	async provideTag(repoFullName: string, tagName: string): Promise<Tag | null> {
+		const tags = await this.provideTags(repoFullName);
+		return tags.find((item) => item.name === tagName) || null;
+	}
+
+	async provideTextSearchResults(
+		repoFullName: string,
+		ref: string,
+		query: TextSearchQuery,
+		options: TextSearchOptions
+	): Promise<TextSearchResults> {
+		return sourcegraphDataSource.provideTextSearchResults(repoFullName, ref, query, options);
+	}
+
+	@trySourcegraphApiFirst
+	async provideCommits(
+		repoFullName: string,
+		options?: CommitsQueryOptions
+	): Promise<(Commit & { files?: ChangedFile[] })[]> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const queryParams = {
+			page: options?.page,
+			per_page: options?.pageSize,
+			sha: options?.from,
+			path: options?.path,
+			author: options?.author,
+		};
+		const requestParams = { owner, repo, ...queryParams };
+		const { data } = await fetcher.request(
+			'GET /projects/{owner}%2F{repo}/repository/commits?per_page={per_page}&page={page}&path={path}&ref_name={sha}',
+			requestParams
+		);
+		return Promise.all(
+			data.map(async (item) => ({
+				sha: item.id,
+				author: item.author_name,
+				email: item.author_email,
+				message: item.message,
+				committer: item.committer_name,
+				createTime: item.created_at ? new Date(item.created_at) : undefined,
+				parents: item.parent_ids.map((parent) => parent) || [],
+				avatarUrl: item.author?.avatar_url || (await this.getAvatars(item.author_email)),
+			}))
+		);
+	}
+
+	@trySourcegraphApiFirst
+	async provideCommit(repoFullName: string, ref: string): Promise<Commit & { files?: ChangedFile[] }> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const requestParams = { owner, repo, ref };
+		const { data } = await fetcher.request('GET /projects/{owner}%2F{repo}/repository/commits/{ref}', requestParams);
+		return {
+			sha: data.id,
+			author: data.author_name,
+			email: data.author_email,
+			message: data.message,
+			committer: data.committer_name,
+			createTime: data.created_at ? new Date(data.created_at) : undefined,
+			parents: data.parent_ids || [],
+			files: data.files?.map((item) => ({
+				path: item.filename || item.previous_filename!,
+				previousPath: item.previous_filename,
+				status: item.status as FileChangeStatus,
+			})),
+			avatarUrl: data?.avatar_url,
+		};
+	}
+
+	@trySourcegraphApiFirst
+	async provideCommitChangedFiles(
+		repoFullName: string,
+		ref: string,
+		_options?: CommonQueryOptions
+	): Promise<ChangedFile[]> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const requestParams = { owner, repo, ref };
+		const { data } = await fetcher.request(
+			'GET /projects/{owner}%2F{repo}/repository/commits/{ref}/diff',
+			requestParams
+		);
+		return (
+			data?.map((item) => ({
+				path: item.new_path || item.old_path!,
+				previousPath: item.old_path,
+				status: item.new_file
+					? FileChangeStatus.Added
+					: item.deleted_file
+					? FileChangeStatus.Removed
+					: item.renamed_file
+					? FileChangeStatus.Renamed
+					: FileChangeStatus.Modified,
+			})) || []
+		);
+	}
+
+	async provideCodeReviews(
+		repoFullName: string,
+		options?: CodeReviewsQueryOptions
+	): Promise<(CodeReview & { files?: ChangedFile[] })[]> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const state = options?.state ? (options.state === CodeReviewState.Open ? 'open' : 'closed') : 'all';
+		// per_page=100&page={page}
+		const queryParams = { state, page: options?.page, per_page: options?.pageSize, creator: options?.creator };
+		const requestParams = { owner, repo, ...queryParams };
+		const { data } = await fetcher.request(
+			'GET /projects/{owner}%2F{repo}/merge_requests?per_page={per_page}&page={page}',
+			requestParams as any
+		);
+
+		return data.map((item) => ({
+			id: `${item.iid}`,
+			title: item.title,
+			state: getPullState(item),
+			creator: item.author?.name || item.author?.username,
+			createTime: new Date(item.created_at),
+			// 有些版本没有merged_at字段
+			mergeTime: item.merged_at ? new Date(item.merged_at) : item.updated_at ? new Date(item.updated_at) : null,
+			closeTime: item.closed_at ? new Date(item.closed_at) : null,
+			head: { label: item.labels[0], commitSha: item.sha },
+			base: { label: item.labels[1], commitSha: '' }, // 获取changes时填充
+			avatarUrl: item.author?.avatar_url,
+		}));
+	}
+
+	async provideCodeReview(repoFullName: string, id: string): Promise<CodeReview & { files?: ChangedFile[] }> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const pullRequestParams = { owner, repo, pull_number: Number(id) };
+		const { data } = await fetcher.request(
+			'GET /projects/{owner}%2F{repo}/merge_requests/{pull_number}',
+			pullRequestParams
+		);
+
+		return {
+			id: `${data.iid}`,
+			title: data.title,
+			state: getPullState(data),
+			creator: data.author?.name || data.author?.username,
+			createTime: new Date(data.created_at),
+			mergeTime: data.merged_at ? new Date(data.merged_at) : null,
+			closeTime: data.closed_at ? new Date(data.closed_at) : null,
+			head: { label: data.labels[0], commitSha: data.diff_refs.head_sha },
+			base: { label: data.labels[1], commitSha: data.diff_refs.base_sha },
+			avatarUrl: data.author?.avatar_url,
+		};
+	}
+
+	async provideCodeReviewChangedFiles(
+		repoFullName: string,
+		id: string,
+		options?: CommonQueryOptions
+	): Promise<ChangedFile[]> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const pageParams = { per_page: options?.pageSize, page: options?.page };
+		const filesRequestParams = { owner, repo, pull_number: Number(id), ...pageParams };
+		const { data } = await fetcher.request(
+			'GET /projects/{owner}%2F{repo}/merge_requests/{pull_number}/changes?per_page={per_page}&page={page}',
+			filesRequestParams
+		);
+
+		return data.changes.map((item) => ({
+			path: item.new_path,
+			previousPath: item.old_path,
+			status: item.new_file
+				? FileChangeStatus.Added
+				: item.deleted_file
+				? FileChangeStatus.Removed
+				: item.renamed_file
+				? FileChangeStatus.Renamed
+				: FileChangeStatus.Modified,
+			head: data.diff_refs.head_sha,
+			base: data.diff_refs.base_sha,
+		}));
+	}
+
+	// @trySourcegraphApiFirst
+	// async provideFileBlameRanges(repoFullName: string, ref: string, path: string): Promise<BlameRange[]> {
+	// 	const fetcher = GitHubFetcher.getInstance();
+	// 	const { owner, repo } = parseRepoFullName(repoFullName);
+	// 	const requestParams = { owner, repo, ref, path };
+	// 	const { data } = await fetcher.graphql(FILE_BLAME_QUERY, requestParams);
+	// 	const blameRanges = (data as any)?.repository?.object?.blame?.ranges;
+
+	// 	return (blameRanges || []).map((item) => ({
+	// 		age: item.age as number,
+	// 		startingLine: item.startingLine as number,
+	// 		endingLine: item.endingLine as number,
+	// 		commit: {
+	// 			sha: item.commit?.sha as string,
+	// 			author: item.commit?.author?.name as string,
+	// 			email: item.commit?.author?.email as string,
+	// 			message: item.commit?.message as string,
+	// 			createTime: new Date(item.commit?.authoredDate),
+	// 			avatarUrl: item.commit?.author?.avatarUrl as string,
+	// 		},
+	// 	}));
+	// }
+
+	@trySourcegraphApiFirst
+	async provideFileBlameRanges(repoFullName: string, ref: string, path: string): Promise<BlameRange[]> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { owner, repo } = parseRepoFullName(repoFullName);
+		const requestParams = { owner, repo, ref, path: encodeURIComponent(path) };
+		const { data } = await fetcher.request(
+			'GET /projects/{owner}%2F{repo}/repository/files/{path}/blame?ref={ref}',
+			requestParams
+		);
+		let startLine = 1;
+		return Promise.all(
+			(data || []).map(async (item) => {
+				let startingLine = startLine;
+				let endingLine = startingLine + item.lines.length;
+				startLine = endingLine + 1;
+				return {
+					// age: item.age as number,
+					startingLine,
+					endingLine,
+					commit: {
+						sha: item.commit?.id as string,
+						author: item.commit?.author_name as string,
+						email: item.commit?.author_email as string,
+						message: item.commit?.message as string,
+						createTime: new Date(item.commit?.authored_date),
+						avatarUrl: item.commit?.avatar_url || (await this.getAvatars(item.commit?.author_email)),
+					},
+				};
+			})
+		);
+	}
+
+	async getAvatars(email: string) {
+		if (this.avatarPromiseMap.has(email)) {
+			return this.avatarPromiseMap.get(email);
+		}
+
+		this.avatarPromiseMap.set(email, this.getAvatar(email));
+		return this.avatarPromiseMap.get(email);
+	}
+
+	async getAvatar(email): Promise<string> {
+		const fetcher = GitLabFetcher.getInstance();
+		const { data } = await fetcher.request('GET /avatar?email={email}', { email });
+		return data.avatar_url;
+	}
+
+	provideSymbolDefinitions(
+		repoFullName: string,
+		ref: string,
+		path: string,
+		line: number,
+		character: number,
+		symbol: string
+	): Promise<SymbolDefinitions> {
+		return sourcegraphDataSource.provideSymbolDefinitions(repoFullName, ref, path, line, character, symbol);
+	}
+
+	async provideSymbolReferences(
+		repoFullName: string,
+		ref: string,
+		path: string,
+		line: number,
+		character: number,
+		symbol: string
+	): Promise<SymbolReferences> {
+		return sourcegraphDataSource.provideSymbolReferences(repoFullName, ref, path, line, character, symbol);
+	}
+
+	async provideSymbolHover(
+		repoFullName: string,
+		ref: string,
+		path: string,
+		line: number,
+		character: number,
+		_symbol: string
+	): Promise<SymbolHover | null> {
+		return sourcegraphDataSource.provideSymbolHover(repoFullName, ref, path, line, character, _symbol);
+	}
+
+	provideUserAvatarLink(user: string): string {
+		return ``;
+	}
+}

--- a/extensions/github1s/src/adapters/gitlab1s/fetcher.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/fetcher.ts
@@ -1,0 +1,158 @@
+/**
+ * @file github api fetcher base octokit
+ * @author netcon
+ */
+
+(self as any).global = self;
+import * as vscode from 'vscode';
+import { getExtensionContext } from '@/helpers/context';
+import { Octokit } from '@octokit/core';
+import { GitLab1sAuthenticationView } from './authentication';
+import { GitLabTokenManager } from './token';
+import { isNil } from '@/helpers/util';
+import { SourcegraphDataSource } from '../sourcegraph/data-source';
+import { GitlabRequest } from './gitlab-request';
+
+export const errorMessages = {
+	rateLimited: {
+		anonymous: 'API Rate Limit Exceeded, please authenticate to github and retry',
+		authenticated: 'API Rate Limit Exceeded for this token, please try another account',
+	},
+	badCredentials: {
+		anonymous: 'Bad credentials, please authenticate to github and retry',
+		authenticated: 'This token is invalid, please try another one',
+	},
+	notFound: {
+		anonymous: 'Repository not found, if it is private, you can provide an AccessToken to access it',
+		authenticated: 'Repository not found, if it is private, you can try change an AccessToken to access it',
+	},
+	noPermission: {
+		anonymous: 'You have no permission for this operation, please authenticate to github and retry',
+		authenticated: 'You have no permission for this operation, please try another account',
+	},
+};
+
+const detectErrorMessage = (response: any, authenticated: boolean, accessRepository: boolean) => {
+	if (response?.status === 403 && +response?.headers?.['x-ratelimit-remaining'] === 0) {
+		return errorMessages.rateLimited[authenticated ? 'authenticated' : 'anonymous'];
+	}
+	if (response?.status === 401 && +response?.data?.message?.includes?.('Unauthorized')) {
+		return errorMessages.badCredentials[authenticated ? 'authenticated' : 'anonymous'];
+	}
+	if (response?.status === 404 && !accessRepository) {
+		return errorMessages.notFound[authenticated ? 'authenticated' : 'anonymous'];
+	}
+	if (response?.status === 403) {
+		return errorMessages.noPermission[authenticated ? 'authenticated' : 'anonymous'];
+	}
+	return response?.data?.message || response?.data?.error || '';
+};
+
+const USE_SOURCEGRAPH_API_FIRST = 'USE_SOURCEGRAPH_API_FIRST';
+
+export class GitLabFetcher {
+	private static instance: GitLabFetcher | null = null;
+	private _emitter = new vscode.EventEmitter<boolean | null | undefined>();
+	private _ownerAndRepoPromise: Promise<[string, string]> | null = null;
+	private _repositoryPromise: Promise<{ private: boolean } | null> | null = null;
+	private _originalRequest: GitlabRequest['request'] | null = null;
+	public onDidChangeUseSourcegraphApiFirst = this._emitter.event;
+
+	public request: GitlabRequest['request'];
+	public graphql: Octokit['graphql'];
+
+	public static getInstance(): GitLabFetcher {
+		if (GitLabFetcher.instance) {
+			return GitLabFetcher.instance;
+		}
+		return (GitLabFetcher.instance = new GitLabFetcher());
+	}
+
+	private constructor() {
+		this.initFetcherMethods();
+		// turn off `useSourcegraphApiFirst` if current repository is private
+		this.useSourcegraphApiFirst().then((useSourcegraphApiFirst) =>
+			this.resolveCurrentRepository(useSourcegraphApiFirst).then(
+				(repository) => repository?.private && !this.setUseSourcegraphApiFirst(false)
+			)
+		);
+		GitLabTokenManager.getInstance().onDidChangeToken(() => this.initFetcherMethods());
+	}
+
+	// initial fetcher methods in this way for correct `request/graphql` type inference
+	initFetcherMethods() {
+		const accessToken = GitLabTokenManager.getInstance().getToken();
+		const gitlabRequest = new GitlabRequest({ accessToken });
+
+		this._originalRequest = gitlabRequest.request;
+		this.request = Object.assign((...args: Parameters<GitlabRequest['request']>) => {
+			return gitlabRequest.request(...args).catch(async (error) => {
+				const errorStatus = (error as any)?.status;
+				if ([401, 403, 404].includes(errorStatus)) {
+					// maybe we have to acquire github access token to continue
+					const repository = await this.resolveCurrentRepository(false);
+					const message = detectErrorMessage(error, !!accessToken, !!repository);
+					await GitLab1sAuthenticationView.getInstance().open(message, true);
+					return gitlabRequest.request(...args);
+				}
+			});
+		}, gitlabRequest.request);
+
+		// this.graphql = Object.assign(async (...args: Parameters<Octokit['graphql']>) => {
+		// 	// graphql API only worked for authenticated users
+		// 	if (!GitLabTokenManager.getInstance().getToken()) {
+		// 		const message = 'GraphQL API only worked for authenticated users';
+		// 		await GitLab1sAuthenticationView.getInstance().open(message, true);
+		// 	}
+		// 	return octokit.graphql(...args);
+		// }, octokit.graphql);
+	}
+
+	private getCurrentOwnerAndRepo() {
+		if (this._ownerAndRepoPromise) {
+			return this._ownerAndRepoPromise;
+		}
+		return (this._ownerAndRepoPromise = new Promise((resolve) => {
+			return vscode.commands.executeCommand('github1s.commands.vscode.getBrowserUrl').then(
+				(browserUrl: string) => {
+					const pathParts = vscode.Uri.parse(browserUrl).path.split('/').filter(Boolean);
+					resolve(pathParts.length >= 2 ? (pathParts.slice(0, 2) as [string, string]) : ['conwnet', 'github1s']);
+				},
+				() => resolve(['conwnet', 'github1s'])
+			);
+		}));
+	}
+
+	private resolveCurrentRepository(useSourcegraphApiFirst: boolean) {
+		if (this._repositoryPromise) {
+			return this._repositoryPromise;
+		}
+		return (this._repositoryPromise = new Promise(async (resolve) => {
+			const [owner = 'conwnet', repo = 'github1s'] = await this.getCurrentOwnerAndRepo();
+			const dataSource = SourcegraphDataSource.getInstance('gitlab');
+			if (useSourcegraphApiFirst && !!(await dataSource.provideRepository(`${owner}/${repo}`).catch((e) => false))) {
+				return resolve({ private: false });
+			}
+			return this._originalRequest?.('GET /projects/{owner}%2F{repo}', { owner, repo }).then(
+				(response) => resolve({ private: response?.data?.visibility === 'private' }),
+				() => resolve(null)
+			);
+		}));
+	}
+
+	public async useSourcegraphApiFirst(repoFullName?: string): Promise<boolean> {
+		const targetRepo = repoFullName || (await this.getCurrentOwnerAndRepo()).join('/');
+		const globalState = getExtensionContext().globalState;
+		const cachedData: Record<string, boolean> | undefined = globalState.get(USE_SOURCEGRAPH_API_FIRST);
+		return !isNil(cachedData?.[targetRepo]) ? !!cachedData?.[targetRepo] : true;
+	}
+
+	public async setUseSourcegraphApiFirst(repoOrValue: string | boolean, value?: boolean) {
+		const targetRepo = !isNil(value) ? (repoOrValue as string) : (await this.getCurrentOwnerAndRepo()).join('/');
+		const targetValue = !isNil(value) ? value : !!repoOrValue;
+		const globalState = getExtensionContext().globalState;
+		const cachedData: Record<string, boolean> | undefined = globalState.get(USE_SOURCEGRAPH_API_FIRST);
+		await globalState.update(USE_SOURCEGRAPH_API_FIRST, { ...cachedData, [targetRepo]: targetValue });
+		this._emitter.fire(value);
+	}
+}

--- a/extensions/github1s/src/adapters/gitlab1s/gitlab-request.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/gitlab-request.ts
@@ -1,0 +1,47 @@
+/**
+ * @file github api auth token manager
+ */
+import { getExtensionContext } from '@/helpers/context';
+import { reuseable } from '@/helpers/func';
+import { GitLabTokenManager } from './token';
+
+const GITLAB_OAUTH_TOKEN = 'gitlab-oauth-token';
+
+let token: string;
+function getToken(): string {
+	token = getExtensionContext().globalState.get(GITLAB_OAUTH_TOKEN) || '';
+	return token;
+}
+
+export class GitlabRequest {
+	accessToken: string;
+
+	constructor({ accessToken }) {
+		this.accessToken = accessToken;
+	}
+
+	public request = reuseable((command: string, params: Record<string, string | number | boolean | undefined>) => {
+		let [method, url] = command.split(' ');
+		Object.keys(params).forEach((el) => {
+			url = url.replace(`{${el}}`, `${params[el]}`);
+		});
+		const fetchOptions = GitLabTokenManager.getInstance().getHeader(this.accessToken);
+		return fetch(`${GITLAB_DOMAIN}/api/v4` + url, {
+			...fetchOptions,
+			method,
+		}).then(async (response) => {
+			const data = await response.json();
+			if (response.status >= 400) {
+				return Promise.reject({
+					status: response.status,
+					data,
+				});
+			}
+
+			if (response.status === 200 || response.status === 304) {
+				return { data, headers: response.headers };
+			}
+			return Promise.reject({ data, headers: response.headers });
+		});
+	});
+}

--- a/extensions/github1s/src/adapters/gitlab1s/graphql.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/graphql.ts
@@ -1,0 +1,32 @@
+/**
+ * @file github graphql queries
+ * @author netcon
+ */
+
+export const FILE_BLAME_QUERY = `
+query fileBlameQuery($owner: String!, $repo: String!, $ref: String!, $path: String!) {
+	repository(owner: $owner, name: $repo) {
+		object(expression: $ref) {
+			... on Commit {
+				blame(path: $path) {
+					ranges {
+						age
+						startingLine
+						endingLine
+						commit {
+							sha: oid
+							message
+							authoredDate
+							author {
+								avatarUrl
+								name
+								email
+							}
+						}
+					}
+				}
+			}
+		}
+	}
+}
+`;

--- a/extensions/github1s/src/adapters/gitlab1s/index.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/index.ts
@@ -3,9 +3,13 @@
  * @author netcon
  */
 
+import * as vscode from 'vscode';
 import { GitLab1sRouterParser } from './router-parser';
-import { SourcegraphDataSource } from '../sourcegraph/data-source';
+import { GitLab1sDataSource } from './data-source';
+// import { SourcegraphDataSource } from '../sourcegraph/data-source';
 import { Adapter, CodeReviewType, PlatformName } from '../types';
+import { GitLab1sSettingsViewProvider } from './settings';
+import { GitLab1sAuthenticationView } from './authentication';
 import { setVSCodeContext } from '@/helpers/vscode';
 
 export class GitLab1sAdapter implements Adapter {
@@ -14,7 +18,8 @@ export class GitLab1sAdapter implements Adapter {
 	public codeReviewType = CodeReviewType.MergeRequest;
 
 	resolveDataSource() {
-		return Promise.resolve(SourcegraphDataSource.getInstance('gitlab'));
+		return Promise.resolve(GitLab1sDataSource.getInstance());
+		// return Promise.resolve(SourcegraphDataSource.getInstance('gitlab'));
 	}
 
 	resolveRouterParser() {
@@ -22,12 +27,25 @@ export class GitLab1sAdapter implements Adapter {
 	}
 
 	activateAsDefault() {
+		// register settings view and show it in activity bar
+		setVSCodeContext('gitlab1s:views:settings:visible', true);
+		setVSCodeContext('github1s:views:codeReviewList:visible', true);
 		setVSCodeContext('github1s:views:commitList:visible', true);
 		setVSCodeContext('github1s:views:fileHistory:visible', true);
 		setVSCodeContext('github1s:features:gutterBlame:enabled', true);
+
+		vscode.window.registerWebviewViewProvider(
+			GitLab1sSettingsViewProvider.viewType,
+			new GitLab1sSettingsViewProvider()
+		);
+		vscode.commands.registerCommand('github1s.commands.openGitHub1sAuthPage', () => {
+			return GitLab1sAuthenticationView.getInstance().open();
+		});
 	}
 
 	deactivateAsDefault() {
+		setVSCodeContext('gitlab1s:views:settings:visible', false);
+		setVSCodeContext('github1s:views:codeReviewList:visible', false);
 		setVSCodeContext('github1s:views:commitList:visible', false);
 		setVSCodeContext('github1s:views:fileHistory:visible', false);
 		setVSCodeContext('github1s:features:gutterBlame:enabled', false);

--- a/extensions/github1s/src/adapters/gitlab1s/router-parser.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/router-parser.ts
@@ -46,6 +46,6 @@ export class GitLab1sRouterParser extends adapterTypes.RouterParser {
 	}
 
 	buildExternalLink(path: string): string {
-		return 'https://gitlab.com' + (path.startsWith('/') ? path : `/${path}`);
+		return GITLAB_DOMAIN + (path.startsWith('/') ? path : `/${path}`);
 	}
 }

--- a/extensions/github1s/src/adapters/gitlab1s/settings.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/settings.ts
@@ -1,0 +1,93 @@
+/**
+ * @file GitLab1s Settings Webview Provider
+ * @author netcon
+ */
+
+import * as vscode from 'vscode';
+import { getExtensionContext } from '@/helpers/context';
+import { createPageHtml, getWebviewOptions } from '@/helpers/page';
+import { GitLabTokenManager } from './token';
+import { GitLabFetcher } from './fetcher';
+
+export const messageApiMap = {
+	info: vscode.window.showInformationMessage,
+	warning: vscode.window.showWarningMessage,
+	error: vscode.window.showErrorMessage,
+};
+
+export class GitLab1sSettingsViewProvider implements vscode.WebviewViewProvider {
+	public static readonly viewType = 'gitlab1s.views.settings';
+
+	public registerListeners(webviewView: vscode.WebviewView) {
+		const tokenManager = GitLabTokenManager.getInstance();
+		const githubFetcher = GitLabFetcher.getInstance();
+
+		webviewView.webview.onDidReceiveMessage((message) => {
+			const commonResponse = { id: message.id, type: message.type };
+			const postMessage = (data?: unknown) => webviewView.webview.postMessage({ ...commonResponse, data });
+
+			switch (message.type) {
+				case 'get-token':
+					postMessage(tokenManager.getToken());
+					break;
+				case 'set-token':
+					tokenManager.setToken(message.data || '').then(() => postMessage());
+					break;
+				case 'validate-token':
+					tokenManager.validateToken(message.data).then((tokenStatus) => postMessage(tokenStatus));
+					break;
+				case 'open-detail-page':
+					vscode.commands.executeCommand('github1s.commands.openGitHub1sAuthPage').then(() => postMessage());
+					break;
+				case 'connect-to-gitlab':
+					vscode.commands.executeCommand('github1s.commands.vscode.connectToGitLab').then((data: any) => {
+						if (data && data.error_description) {
+							vscode.window.showErrorMessage(data.error_description);
+						} else if (data && data.access_token) {
+							GitLabTokenManager.getInstance().setToken(data.access_token || '');
+						}
+						postMessage();
+					});
+					break;
+				case 'call-vscode-message-api':
+					const messageApi = messageApiMap[message.data?.level];
+					messageApi && messageApi(...message.data?.args).then((response) => postMessage(response));
+					break;
+				case 'get-use-sourcegraph-api':
+					githubFetcher.useSourcegraphApiFirst().then((value) => postMessage(value));
+					break;
+				case 'set-use-sourcegraph-api':
+					githubFetcher.setUseSourcegraphApiFirst(message.data);
+					postMessage(message.data);
+					break;
+			}
+		});
+
+		tokenManager.onDidChangeToken((token) => {
+			webviewView.webview.postMessage({ type: 'token-changed', token });
+		});
+		githubFetcher.onDidChangeUseSourcegraphApiFirst((value) => {
+			webviewView.webview.postMessage({ type: 'use-sourcegraph-api-changed', value });
+		});
+	}
+
+	public resolveWebviewView(webviewView: vscode.WebviewView): void | Thenable<void> {
+		const extensionContext = getExtensionContext();
+
+		this.registerListeners(webviewView);
+		webviewView.webview.options = getWebviewOptions(extensionContext.extensionUri);
+
+		const styles = [
+			vscode.Uri.joinPath(extensionContext.extensionUri, 'assets/pages/components.css').toString(),
+			vscode.Uri.joinPath(extensionContext.extensionUri, 'assets/pages/github1s-settings.css').toString(),
+		];
+		const script = Buffer.from(
+			`window.GITLAB_DOMAIN='${GITLAB_DOMAIN}';window.GITLAB_CREATE_TOKEN_URL='${GITLAB_CREATE_TOKEN_URL}'`
+		);
+		const scripts = [
+			'data:text/javascript;base64,' + script.toString('base64'),
+			vscode.Uri.joinPath(extensionContext.extensionUri, 'assets/pages/github1s-settings.js').toString(),
+		];
+		webviewView.webview.html = createPageHtml('GitLab1s Settings', styles, scripts);
+	}
+}

--- a/extensions/github1s/src/adapters/gitlab1s/token.ts
+++ b/extensions/github1s/src/adapters/gitlab1s/token.ts
@@ -1,0 +1,71 @@
+/**
+ * @file github api auth token manager
+ */
+
+import * as vscode from 'vscode';
+import { getExtensionContext } from '@/helpers/context';
+
+const GITLAB_OAUTH_TOKEN = 'gitlab-oauth-token';
+
+export interface TokenStatus {
+	ratelimitLimit: number;
+	ratelimitRemaining: number;
+	ratelimitReset: number;
+	ratelimitResource: number;
+	ratelimitUsed: number;
+}
+
+export class GitLabTokenManager {
+	private static instance: GitLabTokenManager | null = null;
+	private _emitter = new vscode.EventEmitter<string>();
+	public onDidChangeToken = this._emitter.event;
+
+	private constructor() {}
+	public static getInstance(): GitLabTokenManager {
+		if (GitLabTokenManager.instance) {
+			return GitLabTokenManager.instance;
+		}
+		return (GitLabTokenManager.instance = new GitLabTokenManager());
+	}
+
+	public getToken(): string {
+		return getExtensionContext().globalState.get(GITLAB_OAUTH_TOKEN) || '';
+	}
+
+	public getHeader(token?: string): Record<string, Record<string, string>> {
+		const accessToken = token === undefined ? this.getToken() : token;
+		if (!accessToken) {
+			return {};
+		}
+		if (accessToken.length >= 60) {
+			return { headers: { Authorization: `Bearer ${accessToken}` } };
+		}
+		return { headers: { 'PRIVATE-TOKEN': `${accessToken}` } };
+	}
+
+	public async setToken(token: string) {
+		const isTokenChanged = this.getToken() !== token;
+		return getExtensionContext()
+			.globalState.update(GITLAB_OAUTH_TOKEN, token)
+			.then(() => isTokenChanged && this._emitter.fire(token));
+	}
+
+	public async validateToken(token?: string): Promise<TokenStatus | null> {
+		const fetchOptions = this.getHeader(token);
+		return fetch(`${GITLAB_DOMAIN}/api/v4/projects?per_page=1`, fetchOptions)
+			.then((response) => {
+				if (response.status === 401) {
+					return null;
+				}
+				// TODO gitlab does not support get cros headers
+				return {
+					ratelimitLimit: +response.headers.get('ratelimit-limit')! || 0,
+					ratelimitRemaining: +response.headers.get('ratelimit-remaining')! || 0,
+					ratelimitReset: +response.headers.get('ratelimit-reset')! || 0,
+					ratelimitResource: +response.headers.get('ratelimit-resource')! || 0,
+					ratelimitUsed: +response.headers.get('ratelimit-observed')! || 0,
+				};
+			})
+			.catch(() => null);
+	}
+}

--- a/extensions/github1s/src/adapters/sourcegraph/data-source.ts
+++ b/extensions/github1s/src/adapters/sourcegraph/data-source.ts
@@ -61,7 +61,8 @@ export class SourcegraphDataSource extends DataSource {
 			return `github.com/${repo}`;
 		}
 		if (this.platform === 'gitlab') {
-			return `gitlab.com/${repo}`;
+			// return `gitlab.com/${repo}`;
+			return `${GITLAB_DOMAIN.replace('https://', '')}/${repo}`;
 		}
 		if (this.platform === 'bitbucket') {
 			return `bitbucket.org/${repo}`;

--- a/extensions/github1s/src/adapters/types.ts
+++ b/extensions/github1s/src/adapters/types.ts
@@ -44,6 +44,7 @@ export interface Branch {
 	name: string;
 	commitSha?: string;
 	description?: string;
+	isDefault?: boolean;
 }
 
 export interface Tag {
@@ -150,6 +151,8 @@ export interface ChangedFile {
 	path: string;
 	// only exists for renamed file
 	previousPath?: string;
+	head?: string;
+	base?: string;
 }
 
 export interface BlameRange {

--- a/extensions/github1s/src/global.d.ts
+++ b/extensions/github1s/src/global.d.ts
@@ -1,0 +1,9 @@
+/**
+ * gitlab domain
+ */
+declare const GITLAB_DOMAIN: string;
+
+/**
+ * gitlab create token url
+ */
+declare const GITLAB_CREATE_TOKEN_URL: string;

--- a/resources/initialize.js
+++ b/resources/initialize.js
@@ -66,7 +66,7 @@
 			logo: {
 				title: 'Open on GitLab',
 				icon: staticAssetsPrefix + '/config/gitlab.svg',
-				onClick: () => (repository ? openOfficialPage('https://gitlab.com') : openGitHub1sPage()),
+				onClick: () => (repository ? openOfficialPage(GITLAB_DOMAIN) : openGitHub1sPage()),
 			},
 		};
 	} else if (window.location.hostname.match(/\.?bitbucket1s\.org$/i)) {
@@ -194,6 +194,43 @@
 	};
 	/*** end connect to github block ***/
 
+	/*** begin connect to gitlab block ***/
+	// resolves with `{ access_token: string; token_type?: string; scope?: string } | { error: string; error_description: string; }`
+	const ConnectToGitLab = () => {
+		const GITLAB_AUTH_URL =
+			`GITLAB_DOMAIN` +
+			'/oauth/authorize?client_id=d299a460107bb521fbd0c31048c2a6912b94f4f10ce240eb07da5aaa136138e1&redirect_uri=https://h.mxoxw.com/auth&response_type=code&state=STATE&scope=read_api+email';
+		const OPEN_WINDOW_FEATURES =
+			'directories=no,titlebar=no,toolbar=no,location=no,status=no,menubar=no,scrollbars=no,resizable=no,width=800,height=520,top=150,left=150';
+		const AUTH_PAGE_ORIGIN = 'https://auth.gitlab1s.com';
+		const opener = window.open(GITLAB_AUTH_URL, '_blank', OPEN_WINDOW_FEATURES);
+		const timeout = (ms) => new Promise((resolve) => setTimeout(resolve, ms));
+
+		return new Promise((resolve) => {
+			const handleAuthMessage = (event) => {
+				// Note that though the browser block opening window and popup a tip,
+				// the user can be still open it from the tip. In this case, the `opener`
+				// is null, and we should still process the authorizing message
+				const isValidOpener = !!(opener && event.source === opener);
+				const isValidOrigin = event.origin === AUTH_PAGE_ORIGIN;
+				const isValidResponse = event.data ? event.data.type === 'authorizing' : false;
+				if (!isValidOpener || !isValidOrigin || !isValidResponse) {
+					return;
+				}
+				window.removeEventListener('message', handleAuthMessage);
+				resolve(event.data.payload);
+			};
+
+			window.addEventListener('message', handleAuthMessage);
+			// if there isn't any message from opener window in 300s, remove the message handler
+			timeout(300 * 1000).then(() => {
+				window.removeEventListener('message', handleAuthMessage);
+				resolve({ error: 'authorizing_timeout', error_description: 'Authorizing timeout' });
+			});
+		});
+	};
+	/*** end connect to gitlab block ***/
+
 	/*** begin notificaton block ***/
 	const renderNotification = () => {
 		const NOTIFICATION_STORAGE_KEY = 'GITHUB1S_NOTIFICATION';
@@ -265,6 +302,7 @@
 		{ id: 'github1s.commands.vscode.replaceBrowserUrl', handler: (url) => window.history.replaceState(null, '', url) },
 		{ id: 'github1s.commands.vscode.pushBrowserUrl', handler: (url) => window.history.pushState(null, '', url) },
 		{ id: 'github1s.commands.vscode.connectToGitHub', handler: ConnectToGitHub },
+		{ id: 'github1s.commands.vscode.connectToGitLab', handler: ConnectToGitLab },
 	];
 
 	window.vscodeWeb = {

--- a/resources/initialize.js
+++ b/resources/initialize.js
@@ -66,7 +66,7 @@
 			logo: {
 				title: 'Open on GitLab',
 				icon: staticAssetsPrefix + '/config/gitlab.svg',
-				onClick: () => (repository ? openOfficialPage(GITLAB_DOMAIN) : openGitHub1sPage()),
+				onClick: () => (repository ? openOfficialPage(`GITLAB_DOMAIN`) : openGitHub1sPage()),
 			},
 		};
 	} else if (window.location.hostname.match(/\.?bitbucket1s\.org$/i)) {

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -76,6 +76,18 @@ const scanGitHub1sExtensions = () => {
 	return extensions.map((item) => getExtensionData(path.join(APP_ROOT, 'extensions', item))).filter(Boolean);
 };
 
+const getInitialize = () => {
+	try {
+		const initializePath = path.join(APP_ROOT, `resources/initialize.js`);
+		let content = fs.readFileSync(initializePath).toString('utf8');
+		content = content.replace(/GITLAB_DOMAIN/g, process.env.GITLAB_DOMAIN || 'https://gitlab.com');
+		return content;
+	} catch {
+		console.error('Failed to generate initialize.js file.');
+		process.exit(1);
+	}
+};
+
 const VSCODE_NODE_MODULES = [
 	'@vscode/iconv-lite-umd',
 	'@vscode/vscode-languagedetection',
@@ -140,7 +152,7 @@ module.exports = {
 					},
 				},
 				{
-					from: 'resources/{initialize.js,github.svg,gitlab.svg,bitbucket.svg,npm.svg}',
+					from: 'resources/{github.svg,gitlab.svg,bitbucket.svg,npm.svg}',
 					to: 'static/config/[name][ext]',
 				},
 				...VSCODE_NODE_MODULES,
@@ -164,6 +176,10 @@ module.exports = {
 				const extensions = [...vscodeExtensions, ...scanGitHub1sExtensions()];
 				return `window.github1sExtensions = ${JSON.stringify(extensions)};`;
 			},
+		}),
+		generate({
+			file: 'static/config/initialize.js',
+			content: () => getInitialize(),
 		}),
 	],
 	devServer: {


### PR DESCRIPTION
- Add support for personal repo.
- Add environment variables to support custom settings.

> - `GITLAB_DOMAIN` gitlab domain, default is `https://gitlab.com`
> - `GITLAB_CREATE_TOKEN_URL` gitlab authorization url, default is `/-/profile/personal_access_tokens`