### PR TITLE
fix: border styles for input on authorization page

### DIFF
--- a/extensions/github1s/assets/pages/components.css
+++ b/extensions/github1s/assets/pages/components.css
@@ -55,7 +55,7 @@
   outline: 1px solid transparent;
   font-family: var(--vscode-font-family);
   color: var(--vscode-input-foreground);
-  border: 1px solid var(--vscode-input-foreground);
+  border: 1px solid var(--vscode-input-border, var(--vscode-widget-border));
   background-color: var(--vscode-input-background);
 }
 

--- a/extensions/github1s/assets/pages/components.css
+++ b/extensions/github1s/assets/pages/components.css
@@ -55,7 +55,7 @@
   outline: 1px solid transparent;
   font-family: var(--vscode-font-family);
   color: var(--vscode-input-foreground);
-  border: 1px solid var(--vscode-input-background);
+  border: 1px solid var(--vscode-input-foreground);
   background-color: var(--vscode-input-background);
 }
 


### PR DESCRIPTION
use `--vscode-input-border` for border

> ![image](https://github.com/conwnet/github1s/assets/2452450/03a81677-29a0-4a25-bf26-f657252d063f)

![telegram-cloud-photo-size-1-5026487079793699676-y](https://github.com/conwnet/github1s/assets/2452450/190eecb6-2531-4fb1-aa70-41087efbc40b)
