### PR TITLE
docs: fix broken stargazers chart

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ We are partnered with [OSS Insight](https://ossinsight.io/?utm_source=github1s&u
 
 ## Stargazers over time
 
-[![Stargazers over time](https://api.star-history.com/svg?repos=conwnet/github1s&type=Date)](https://star-history.com/#conwnet/github1s&Date)
+[![Stargazers over time](https://star-history.dera.page/svg?repos=conwnet/github1s&type=Date)](https://star-history.dera.page/#conwnet/github1s&Date)
 
 <details>
 <summary>Third-party Related Projects</summary>


### PR DESCRIPTION
The "Stargazers over time" chart on the README has been broken for a while due to GitHub stargazer API restrictions. This PR switches the chart to the maintained star-history.dera.page instance, which uses an alternative data source that requires no API token, restoring the chart.