### PR TITLE
fix: github1s empty path

### DIFF
--- a/extensions/github1s/src/adapters/github1s/data-source.ts
+++ b/extensions/github1s/src/adapters/github1s/data-source.ts
@@ -176,7 +176,7 @@ export class GitHub1sDataSource extends DataSource {
 				const response = await fetcher.request(requestUrl, requestParams).catch(reject);
 				response?.data?.ref && this.matchedRefsMap.get(repoFullName)?.push(response.data.ref);
 				const result = response?.data || { ref: 'HEAD', path: '/' };
-				return resolve({ ...result, path: normalizePath(result.path) });
+				return resolve({ ...result, path: normalizePath(result.path || '') });
 			});
 			this.refPathPromiseMap.set(mapKey, refPathPromise);
 		}


### PR DESCRIPTION
Fix the bug where URLs without file paths cannot be displayed properly when opening on Github1s