### PR TITLE
fix: npmjs1s fails without version

### DIFF
--- a/extensions/github1s/src/adapters/npmjs1s/data-source.ts
+++ b/extensions/github1s/src/adapters/npmjs1s/data-source.ts
@@ -51,10 +51,13 @@ export class Npmjs1sDataSource extends DataSource {
 	getPackageFiles(packageName: string, version: string): Promise<PackageEntry[]> {
 		const mapKey = `${packageName} ${version}`;
 		if (!this._filesPromiseMap.has(mapKey)) {
-			const requestUrl = `https://unpkg.com/${packageName}@${version}/?meta`;
-			const filesPromise = fetch(requestUrl)
-				.then((response) => response.json())
-				.then((data) => data?.files || []);
+			const filesPromise = (async () => {
+				const packageVersions = version === 'latest' ? await this.getPackageVersions(packageName) : [];
+				const exactVersion = packageVersions.find((packageVersion) => packageVersion.tag === 'latest')?.name || version;
+				const requestUrl = `https://unpkg.com/${packageName}@${exactVersion}/?meta`;
+				const data = await fetch(requestUrl).then((response) => response.json());
+				return data?.files || [];
+			})();
 			this._filesPromiseMap.set(mapKey, filesPromise);
 		}
 		return this._filesPromiseMap.get(mapKey)!;
@@ -86,7 +89,9 @@ export class Npmjs1sDataSource extends DataSource {
 				const data = await fetch(requestUrl).then((response) => response.json(), reject);
 				const tagEntries = Object.entries(data?.['dist-tags'] || {}) as [string, string][];
 				const versionTag = tagEntries.reduce((prevVersionTag, [tag, version]) => {
-					prevVersionTag[version] = tag;
+					if (!prevVersionTag[version] || tag === 'latest') {
+						prevVersionTag[version] = tag;
+					}
 					return prevVersionTag;
 				}, {}) as Record<string, string>;
 				const packageVersions = Object.keys(data?.versions || {}).map((version) => {

--- a/extensions/github1s/src/providers/file-system/index.ts
+++ b/extensions/github1s/src/providers/file-system/index.ts
@@ -68,7 +68,8 @@ export class GitHub1sFileSystemProvider implements FileSystemProvider, Disposabl
 			const pathParts = dirname(entry.path).split('/').filter(Boolean);
 			pathParts.forEach((part) => {
 				if (!(current.entries || (current.entries = new Map<string, Entry>())).has(part)) {
-					current.entries.set(part, createEntry(adapterTypes.FileType.Directory, current.uri, current.name));
+					const entryUri = Uri.joinPath(current.uri, current.name);
+					current.entries.set(part, createEntry(adapterTypes.FileType.Directory, entryUri, part));
 				}
 				current = current.entries.get(part) as Directory;
 			});

--- a/extensions/github1s/src/providers/file-system/types.ts
+++ b/extensions/github1s/src/providers/file-system/types.ts
@@ -39,7 +39,7 @@ export class Directory implements FileStat {
 	isSubmodule: boolean;
 
 	constructor(
-		public uri: Uri,
+		public uri: Uri, // parent directory uri
 		name: string,
 		options?: any,
 	) {


### PR DESCRIPTION
npmjs1s uses unpkg to get file lists, which was previously ok but now fails due to CORS errors when passing `latest` as a version number.