### PR TITLE
feat: use tree-file-list api

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -3,7 +3,7 @@ import tseslint from 'typescript-eslint';
 import eslintPluginPrettierRecommended from 'eslint-plugin-prettier/recommended';
 
 export default [
-	{ ignores: ['**/dist', '**/assets', 'vscode-web/lib', '**/vs', '**/vscode.proposed.d.ts'] },
+	{ ignores: ['**/dist', '**/out', '**/assets', 'vscode-web/lib', '**/vs', '**/vscode.proposed.d.ts'] },
 	...tseslint.configs.recommended,
 	jsdoc.configs['flat/recommended-typescript'],
 	eslintPluginPrettierRecommended,

--- a/extensions/github1s/src/adapters/github1s/data-source.ts
+++ b/extensions/github1s/src/adapters/github1s/data-source.ts
@@ -105,10 +105,29 @@ export class GitHub1sDataSource extends DataSource {
 	@trySourcegraphApiFirst
 	async provideDirectory(repoFullName: string, ref: string, path: string, recursive = false): Promise<Directory> {
 		const fetcher = GitHubFetcher.getInstance();
+		const repositoryParams = parseRepoFullName(repoFullName);
+		if (recursive) {
+			const response = await fetcher
+				.request('GET /repos/{owner}/{repo}/git/tree-file-list/{ref}', { ref, ...repositoryParams })
+				.catch(() => null);
+			const filePaths = response?.data;
+			if (Array.isArray(filePaths) && filePaths.every(isString)) {
+				const directoryPath = path.split('/').filter(Boolean).join('/');
+				const directoryPrefix = directoryPath ? `${directoryPath}/` : '';
+				const entries: DirectoryEntry[] = filePaths
+					.filter((filePath: string) => filePath.startsWith(directoryPrefix))
+					.map((filePath: string) => ({
+						path: concatPath(path, filePath.slice(directoryPrefix.length)),
+						type: FileType.File,
+					}));
+				return { entries, truncated: false };
+			}
+		}
+
 		const encodedPath = trimStart(encodeFilePath(path), '/');
 		// github api will return all files if `recursive` exists, even the value if false
 		const recursiveParams = recursive ? { recursive } : {};
-		const requestParams = { ref, path: encodedPath, ...parseRepoFullName(repoFullName), ...recursiveParams };
+		const requestParams = { ref, path: encodedPath, ...repositoryParams, ...recursiveParams };
 		const { data } = await fetcher.request('GET /repos/{owner}/{repo}/git/trees/{ref}:{path}', requestParams);
 		const parseTreeItem = (treeItem): DirectoryEntry => ({
 			path: concatPath(path, treeItem.path),

--- a/package.json
+++ b/package.json
@@ -11,18 +11,19 @@
     "watch-with-vscode": "DEV_VSCODE=true npm run watch",
     "link": "node scripts/link.js",
     "format": "prettier --write .",
-    "eslint": "eslint --fix",
+    "eslint": "eslint . --fix",
+    "eslint:check": "eslint .",
     "typecheck": "tsc --noEmit && tsc --noEmit -p functions/tsconfig.json",
     "test:ci": "start-test watch:dev-server 8080 test",
     "test": "cd tests && npm install && npx playwright install && npm run test",
     "postinstall": "husky install && node scripts/postinstall.js"
   },
   "lint-staged": {
-    "*.{js,ts}": [
+    "*.{js,jsx,mjs,cjs,ts,tsx,mts,cts}": [
       "prettier --write",
       "eslint --fix"
     ],
-    "*.{json.css,md,yml,yaml}": [
+    "*.{json,css,md,yml,yaml}": [
       "prettier --write"
     ]
   },


### PR DESCRIPTION
Prefer the untruncated tree file list for recursive requests and fall back to the Trees API on failure.